### PR TITLE
tools: fix Toollet static{}

### DIFF
--- a/src/test/java/com/xiaomi/infra/pegasus/tools/Toollet.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/tools/Toollet.java
@@ -36,11 +36,10 @@ public class Toollet {
             int process_id = -1;
             while ((line = input.readLine()) != null) {
                 if (line.contains("pegasus_server") && line.contains("meta")) {
-                    String[] words = line.split(" ");
-                    for (String word : words) {
+                    String[] words = line.split("\\s+");
+                    if (words.length > 1) {
                         try {
-                            process_id = Integer.valueOf(word);
-                            break;
+                            process_id = Integer.valueOf(words[1]);
                         } catch (Throwable ex) {
                         }
                     }


### PR DESCRIPTION
If the length of the username is greater than the length of the display column, the numeric user ID is displayed instead. Toollet may take the user ID as process ID. So here, we need to fix it.