### PR TITLE
add createClient API with clientOptions

### DIFF
--- a/src/main/java/com/xiaomi/infra/pegasus/client/ClientOptions.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/ClientOptions.java
@@ -99,10 +99,11 @@ public class ClientOptions {
     if (options instanceof ClientOptions) {
       ClientOptions clientOptions = (ClientOptions) options;
       return this.metaServers.equals(clientOptions.metaServers)
-          && this.operationTimeout == clientOptions.operationTimeout
+          && this.operationTimeout.toMillis() == clientOptions.operationTimeout.toMillis()
           && this.asyncWorkers == clientOptions.asyncWorkers
           && this.enablePerfCounter == clientOptions.enablePerfCounter
-          && this.falconPushInterval == clientOptions.falconPushInterval;
+          && this.falconPerfCounterTags.equals(clientOptions.falconPerfCounterTags)
+          && this.falconPushInterval.toMillis() == clientOptions.falconPushInterval.toMillis();
     }
     return false;
   }

--- a/src/main/java/com/xiaomi/infra/pegasus/client/ClientOptions.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/ClientOptions.java
@@ -1,7 +1,7 @@
-package com.xiaomi.infra.pegasus.client;
 // Copyright (c) 2019, Xiaomi, Inc.  All rights reserved.
 // This source code is licensed under the Apache License Version 2.0, which
 // can be found in the LICENSE file in the root directory of this source tree.
+package com.xiaomi.infra.pegasus.client;
 
 public class ClientOptions {
   String metaServers = "127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603";

--- a/src/main/java/com/xiaomi/infra/pegasus/client/ClientOptions.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/ClientOptions.java
@@ -1,0 +1,36 @@
+package com.xiaomi.infra.pegasus.client;
+// Copyright (c) 2019, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+public class ClientOptions {
+  String metaServers = "127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603";
+  int timeout = 1000;
+
+  public ClientOptions() {}
+
+  public ClientOptions(String metaServers, int timeout) {
+    this.metaServers = metaServers;
+    this.timeout = timeout;
+  }
+
+  @Override
+  public boolean equals(Object options) {
+    if (this == options) {
+      return true;
+    }
+    if (options instanceof ClientOptions) {
+      ClientOptions clientOptions = (ClientOptions) options;
+      if (this.metaServers.equals(clientOptions.metaServers)
+          && this.timeout == clientOptions.timeout) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return "ClientOptions{" + "metaServers='" + metaServers + '\'' + ", timeout=" + timeout + '}';
+  }
+}

--- a/src/main/java/com/xiaomi/infra/pegasus/client/ClientOptions.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/ClientOptions.java
@@ -3,15 +3,121 @@
 // can be found in the LICENSE file in the root directory of this source tree.
 package com.xiaomi.infra.pegasus.client;
 
+import java.time.Duration;
+
+/**
+ * @author jiashuo1
+ *     <p>This class provides method to create an instance of {@link ClientOptions}.you can use
+ *     <code>
+ *         ClientOptions.create();
+ *     </code>
+ *     <p>to create a new instance of {@link ClientOptions} with default settings, or use such as
+ *     <code>
+ *         ClientOptions.builder().metaServers("127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603")
+ *  *     .operationTimeout(Duration.ofMillis(1000)).asyncWorkers(4).enablePerfCounter(false)
+ *  *     .falconPerfCounterTags("").falconPushInterval(Duration.ofSeconds(10)).build();
+ *     </code>
+ *     <p>to create an instance {@link ClientOptions} with custom settings.
+ */
 public class ClientOptions {
-  String metaServers = "127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603";
-  int timeout = 1000;
 
-  public ClientOptions() {}
+  /**
+   * The list of meta server addresses, separated by commas.
+   *
+   * <p>Required field.
+   */
+  public static final String DEFAULT_META_SERVERS =
+      "127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603";
 
-  public ClientOptions(String metaServers, int timeout) {
-    this.metaServers = metaServers;
-    this.timeout = timeout;
+  /**
+   * The timeout for failing to finish an operation.
+   *
+   * <p>Default: 1000ms
+   */
+  public static final Duration DEFAULT_OPERATION_TIMEOUT = Duration.ofMillis(1000);
+
+  /**
+   * The number of background worker threads. Internally it is the number of Netty NIO threads for
+   * handling RPC events between client and Replica Servers.
+   *
+   * <p>Default: 4
+   */
+  public static final int DEFAULT_ASYNC_WORKERS = 4;
+
+  /**
+   * Whether to enable performance statistics. If true, the client will periodically report metrics
+   * to local falcon agent (currently we only support falcon as monitoring system).
+   *
+   * <p>Default: false
+   */
+  public static final boolean DEFAULT_ENABLE_PERF_COUNTER = false;
+
+  /**
+   * Additional tags for falcon metrics. For example:
+   * "cluster=c3srv-ad,job=recommend-service-history"
+   *
+   * <p>Default: empty string.
+   */
+  public static final String DEFAULT_FALCON_PERF_COUNTER_TAGS = "";
+
+  /**
+   * The interval to report metrics to local falcon agent.
+   *
+   * <p>Default: 10s
+   */
+  public static final Duration DEFAULT_FALCON_PUSH_INTERVAL = Duration.ofSeconds(10);
+
+  private final String metaServers;
+  private final Duration operationTimeout;
+  private final int asyncWorkers;
+  private final boolean enablePerfCounter;
+  private final String falconPerfCounterTags;
+  private final Duration falconPushInterval;
+
+  protected ClientOptions(Builder builder) {
+    this.metaServers = builder.metaServers;
+    this.operationTimeout = builder.operationTimeout;
+    this.asyncWorkers = builder.asyncWorkers;
+    this.enablePerfCounter = builder.enablePerfCounter;
+    this.falconPerfCounterTags = builder.falconPerfCounterTags;
+    this.falconPushInterval = builder.falconPushInterval;
+  }
+
+  protected ClientOptions(ClientOptions original) {
+    this.metaServers = original.getMetaServers();
+    this.operationTimeout = original.getOperationTimeout();
+    this.asyncWorkers = original.getAsyncWorkers();
+    this.enablePerfCounter = original.isEnablePerfCounter();
+    this.falconPerfCounterTags = original.getFalconPerfCounterTags();
+    this.falconPushInterval = original.getFalconPushInterval();
+  }
+
+  /**
+   * Create a copy of {@literal options}
+   *
+   * @param options the original
+   * @return A new instance of {@link ClientOptions} containing the values of {@literal options}
+   */
+  public static ClientOptions copyOf(ClientOptions options) {
+    return new ClientOptions(options);
+  }
+
+  /**
+   * Returns a new {@link ClientOptions.Builder} to construct {@link ClientOptions}.
+   *
+   * @return a new {@link ClientOptions.Builder} to construct {@link ClientOptions}.
+   */
+  public static ClientOptions.Builder builder() {
+    return new ClientOptions.Builder();
+  }
+
+  /**
+   * Create a new instance of {@link ClientOptions} with default settings.
+   *
+   * @return a new instance of {@link ClientOptions} with default settings
+   */
+  public static ClientOptions create() {
+    return builder().build();
   }
 
   @Override
@@ -22,7 +128,10 @@ public class ClientOptions {
     if (options instanceof ClientOptions) {
       ClientOptions clientOptions = (ClientOptions) options;
       if (this.metaServers.equals(clientOptions.metaServers)
-          && this.timeout == clientOptions.timeout) {
+          && this.operationTimeout == clientOptions.operationTimeout
+          && this.asyncWorkers == clientOptions.asyncWorkers
+          && this.enablePerfCounter == clientOptions.enablePerfCounter
+          && this.falconPushInterval == clientOptions.falconPushInterval) {
         return true;
       }
     }
@@ -31,6 +140,114 @@ public class ClientOptions {
 
   @Override
   public String toString() {
-    return "ClientOptions{" + "metaServers='" + metaServers + '\'' + ", timeout=" + timeout + '}';
+    return "ClientOptions{"
+        + "metaServers='"
+        + metaServers
+        + '\''
+        + ", operationTimeout(ms)="
+        + operationTimeout.toMillis()
+        + ", asyncWorkers="
+        + asyncWorkers
+        + ", enablePerfCounter="
+        + enablePerfCounter
+        + ", falconPerfCounterTags='"
+        + falconPerfCounterTags
+        + '\''
+        + ", falconPushInterval(s)="
+        + falconPushInterval.getSeconds()
+        + '}';
+  }
+
+  public static class Builder {
+    private String metaServers = DEFAULT_META_SERVERS;
+    private Duration operationTimeout = DEFAULT_OPERATION_TIMEOUT;
+    private int asyncWorkers = DEFAULT_ASYNC_WORKERS;
+    private boolean enablePerfCounter = DEFAULT_ENABLE_PERF_COUNTER;
+    private String falconPerfCounterTags = DEFAULT_FALCON_PERF_COUNTER_TAGS;
+    private Duration falconPushInterval = DEFAULT_FALCON_PUSH_INTERVAL;
+
+    protected Builder() {}
+
+    public Builder metaServers(String metaServers) {
+      this.metaServers = metaServers;
+      return this;
+    }
+
+    public Builder operationTimeout(Duration operationTimeout) {
+      this.operationTimeout = operationTimeout;
+      return this;
+    }
+
+    public Builder asyncWorkers(int asyncWorkers) {
+      this.asyncWorkers = asyncWorkers;
+      return this;
+    }
+
+    public Builder enablePerfCounter(boolean enablePerfCounter) {
+      this.enablePerfCounter = enablePerfCounter;
+      return this;
+    }
+
+    public Builder falconPerfCounterTags(String falconPerfCounterTags) {
+      this.falconPerfCounterTags = falconPerfCounterTags;
+      return this;
+    }
+
+    public Builder falconPushInterval(Duration falconPushInterval) {
+      this.falconPushInterval = falconPushInterval;
+      return this;
+    }
+
+    /**
+     * Create a new instance of {@link ClientOptions}.
+     *
+     * @return new instance of {@link ClientOptions}
+     */
+    public ClientOptions build() {
+      return new ClientOptions(this);
+    }
+  }
+
+  /**
+   * Returns a builder to create new {@link ClientOptions} whose settings are replicated from the
+   * current {@link ClientOptions}.
+   *
+   * @return a {@link ClientOptions.Builder} to create new {@link ClientOptions} whose settings are
+   *     replicated from the current {@link ClientOptions}.
+   */
+  public ClientOptions.Builder mutate() {
+    Builder builder = new Builder();
+    builder
+        .metaServers(getMetaServers())
+        .operationTimeout(getOperationTimeout())
+        .asyncWorkers(getAsyncWorkers())
+        .enablePerfCounter(isEnablePerfCounter())
+        .falconPerfCounterTags(getFalconPerfCounterTags())
+        .falconPushInterval(getFalconPushInterval());
+    return builder;
+  }
+
+  public String getMetaServers() {
+    return metaServers;
+  }
+
+  public Duration getOperationTimeout() {
+    return operationTimeout;
+  }
+
+  public int getAsyncWorkers() {
+    return asyncWorkers;
+  }
+
+  public boolean isEnablePerfCounter() {
+    return enablePerfCounter;
+  }
+
+  public String getFalconPerfCounterTags() {
+    return falconPerfCounterTags;
+  }
+
+  public Duration getFalconPushInterval() {
+    return falconPushInterval;
   }
 }

--- a/src/main/java/com/xiaomi/infra/pegasus/client/ClientOptions.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/ClientOptions.java
@@ -21,50 +21,12 @@ import java.time.Duration;
  */
 public class ClientOptions {
 
-  /**
-   * The list of meta server addresses, separated by commas.
-   *
-   * <p>Required field.
-   */
   public static final String DEFAULT_META_SERVERS =
       "127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603";
-
-  /**
-   * The timeout for failing to finish an operation.
-   *
-   * <p>Default: 1000ms
-   */
   public static final Duration DEFAULT_OPERATION_TIMEOUT = Duration.ofMillis(1000);
-
-  /**
-   * The number of background worker threads. Internally it is the number of Netty NIO threads for
-   * handling RPC events between client and Replica Servers.
-   *
-   * <p>Default: 4
-   */
   public static final int DEFAULT_ASYNC_WORKERS = 4;
-
-  /**
-   * Whether to enable performance statistics. If true, the client will periodically report metrics
-   * to local falcon agent (currently we only support falcon as monitoring system).
-   *
-   * <p>Default: false
-   */
   public static final boolean DEFAULT_ENABLE_PERF_COUNTER = false;
-
-  /**
-   * Additional tags for falcon metrics. For example:
-   * "cluster=c3srv-ad,job=recommend-service-history"
-   *
-   * <p>Default: empty string.
-   */
   public static final String DEFAULT_FALCON_PERF_COUNTER_TAGS = "";
-
-  /**
-   * The interval to report metrics to local falcon agent.
-   *
-   * <p>Default: 10s
-   */
   public static final Duration DEFAULT_FALCON_PUSH_INTERVAL = Duration.ofSeconds(10);
 
   private final String metaServers;
@@ -168,31 +130,75 @@ public class ClientOptions {
 
     protected Builder() {}
 
+    /**
+     * the list of meta server addresses, separated by commas, See {@link #DEFAULT_META_SERVERS}
+     *
+     * @param metaServers required field,must be the right meta_servers
+     * @return {@code this}
+     */
     public Builder metaServers(String metaServers) {
       this.metaServers = metaServers;
       return this;
     }
 
+    /**
+     * The timeout for failing to finish an operation,Defaults to {@literal 1000ms}, see {@link
+     * #DEFAULT_OPERATION_TIMEOUT}
+     *
+     * @param operationTimeout operationTimeout
+     * @return {@code this}
+     */
     public Builder operationTimeout(Duration operationTimeout) {
       this.operationTimeout = operationTimeout;
       return this;
     }
 
+    /**
+     * The number of background worker threads. Internally it is the number of Netty NIO threads for
+     * handling RPC events between client and Replica Servers.Defaults to {@literal 4},see {@link
+     * #DEFAULT_ASYNC_WORKERS}
+     *
+     * @param asyncWorkers asyncWorkers thread number
+     * @return {@code this}
+     */
     public Builder asyncWorkers(int asyncWorkers) {
       this.asyncWorkers = asyncWorkers;
       return this;
     }
 
+    /**
+     * Whether to enable performance statistics. If true, the client will periodically report
+     * metrics to local falcon agent (currently we only support falcon as monitoring
+     * system).Defaults to {@literal true},see {@link #DEFAULT_ENABLE_PERF_COUNTER}
+     *
+     * @param enablePerfCounter enablePerfCounter
+     * @return {@code this}
+     */
     public Builder enablePerfCounter(boolean enablePerfCounter) {
       this.enablePerfCounter = enablePerfCounter;
       return this;
     }
 
+    /**
+     * Additional tags for falcon metrics. For example:
+     * "cluster=c3srv-ad,job=recommend-service-history",Default is empty string,see {@link
+     * #DEFAULT_FALCON_PERF_COUNTER_TAGS}
+     *
+     * @param falconPerfCounterTags falconPerfCounterTags
+     * @return {@code this}
+     */
     public Builder falconPerfCounterTags(String falconPerfCounterTags) {
       this.falconPerfCounterTags = falconPerfCounterTags;
       return this;
     }
 
+    /**
+     * The interval to report metrics to local falcon agent,Defaults to {@literal 10s},see {@link
+     * #DEFAULT_FALCON_PUSH_INTERVAL}
+     *
+     * @param falconPushInterval falconPushInterval
+     * @return {@code this}
+     */
     public Builder falconPushInterval(Duration falconPushInterval) {
       this.falconPushInterval = falconPushInterval;
       return this;

--- a/src/main/java/com/xiaomi/infra/pegasus/client/ClientOptions.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/ClientOptions.java
@@ -6,18 +6,27 @@ package com.xiaomi.infra.pegasus.client;
 import java.time.Duration;
 
 /**
- * @author jiashuo1
- *     <p>This class provides method to create an instance of {@link ClientOptions}.you can use
- *     <code>
- *         ClientOptions.create();
- *     </code>
- *     <p>to create a new instance of {@link ClientOptions} with default settings, or use such as
- *     <code>
- *         ClientOptions.builder().metaServers("127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603")
- *  *     .operationTimeout(Duration.ofMillis(1000)).asyncWorkers(4).enablePerfCounter(false)
- *  *     .falconPerfCounterTags("").falconPushInterval(Duration.ofSeconds(10)).build();
- *     </code>
- *     <p>to create an instance {@link ClientOptions} with custom settings.
+ * Client Options to control the behavior of {@link PegasusClientInterface}.
+ *
+ * <p>To create a new instance with default settings:
+ *
+ * <pre>{@code
+ * ClientOptions.create();
+ * }</pre>
+ *
+ * To customize the settings:
+ *
+ * <pre>{@code
+ * ClientOptions opts =
+ *      ClientOptions.builder()
+ *          .metaServers("127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603")
+ *          .operationTimeout(Duration.ofMillis(1000))
+ *          .asyncWorkers(4)
+ *          .enablePerfCounter(false)
+ *          .falconPerfCounterTags("")
+ *          .falconPushInterval(Duration.ofSeconds(10))
+ *          .build();
+ * }</pre>
  */
 public class ClientOptions {
 
@@ -89,13 +98,11 @@ public class ClientOptions {
     }
     if (options instanceof ClientOptions) {
       ClientOptions clientOptions = (ClientOptions) options;
-      if (this.metaServers.equals(clientOptions.metaServers)
+      return this.metaServers.equals(clientOptions.metaServers)
           && this.operationTimeout == clientOptions.operationTimeout
           && this.asyncWorkers == clientOptions.asyncWorkers
           && this.enablePerfCounter == clientOptions.enablePerfCounter
-          && this.falconPushInterval == clientOptions.falconPushInterval) {
-        return true;
-      }
+          && this.falconPushInterval == clientOptions.falconPushInterval;
     }
     return false;
   }
@@ -120,6 +127,7 @@ public class ClientOptions {
         + '}';
   }
 
+  /** Builder for {@link ClientOptions}. */
   public static class Builder {
     private String metaServers = DEFAULT_META_SERVERS;
     private Duration operationTimeout = DEFAULT_OPERATION_TIMEOUT;
@@ -131,9 +139,9 @@ public class ClientOptions {
     protected Builder() {}
 
     /**
-     * the list of meta server addresses, separated by commas, See {@link #DEFAULT_META_SERVERS}
+     * The list of meta server addresses, separated by commas, See {@link #DEFAULT_META_SERVERS}.
      *
-     * @param metaServers required field,must be the right meta_servers
+     * @param metaServers must not be {@literal null} or empty.
      * @return {@code this}
      */
     public Builder metaServers(String metaServers) {
@@ -142,8 +150,8 @@ public class ClientOptions {
     }
 
     /**
-     * The timeout for failing to finish an operation,Defaults to {@literal 1000ms}, see {@link
-     * #DEFAULT_OPERATION_TIMEOUT}
+     * The timeout for failing to finish an operation. Defaults to {@literal 1000ms}, see {@link
+     * #DEFAULT_OPERATION_TIMEOUT}.
      *
      * @param operationTimeout operationTimeout
      * @return {@code this}
@@ -155,8 +163,8 @@ public class ClientOptions {
 
     /**
      * The number of background worker threads. Internally it is the number of Netty NIO threads for
-     * handling RPC events between client and Replica Servers.Defaults to {@literal 4},see {@link
-     * #DEFAULT_ASYNC_WORKERS}
+     * handling RPC events between client and Replica Servers. Defaults to {@literal 4}, see {@link
+     * #DEFAULT_ASYNC_WORKERS}.
      *
      * @param asyncWorkers asyncWorkers thread number
      * @return {@code this}
@@ -168,8 +176,8 @@ public class ClientOptions {
 
     /**
      * Whether to enable performance statistics. If true, the client will periodically report
-     * metrics to local falcon agent (currently we only support falcon as monitoring
-     * system).Defaults to {@literal true},see {@link #DEFAULT_ENABLE_PERF_COUNTER}
+     * metrics to local falcon agent (currently we only support falcon as monitoring system).
+     * Defaults to {@literal false}, see {@link #DEFAULT_ENABLE_PERF_COUNTER}.
      *
      * @param enablePerfCounter enablePerfCounter
      * @return {@code this}
@@ -181,8 +189,8 @@ public class ClientOptions {
 
     /**
      * Additional tags for falcon metrics. For example:
-     * "cluster=c3srv-ad,job=recommend-service-history",Default is empty string,see {@link
-     * #DEFAULT_FALCON_PERF_COUNTER_TAGS}
+     * "cluster=c3srv-ad,job=recommend-service-history". Defaults to empty string, see {@link
+     * #DEFAULT_FALCON_PERF_COUNTER_TAGS}.
      *
      * @param falconPerfCounterTags falconPerfCounterTags
      * @return {@code this}
@@ -193,8 +201,8 @@ public class ClientOptions {
     }
 
     /**
-     * The interval to report metrics to local falcon agent,Defaults to {@literal 10s},see {@link
-     * #DEFAULT_FALCON_PUSH_INTERVAL}
+     * The interval to report metrics to local falcon agent. Defaults to {@literal 10s}, see {@link
+     * #DEFAULT_FALCON_PUSH_INTERVAL}.
      *
      * @param falconPushInterval falconPushInterval
      * @return {@code this}
@@ -207,7 +215,7 @@ public class ClientOptions {
     /**
      * Create a new instance of {@link ClientOptions}.
      *
-     * @return new instance of {@link ClientOptions}
+     * @return new instance of {@link ClientOptions}.
      */
     public ClientOptions build() {
       return new ClientOptions(this);
@@ -233,26 +241,59 @@ public class ClientOptions {
     return builder;
   }
 
+  /**
+   * The list of meta server addresses, separated by commas.
+   *
+   * @return the list of meta server addresses.
+   */
   public String getMetaServers() {
     return metaServers;
   }
 
+  /**
+   * The timeout for failing to finish an operation. Defaults to {@literal 1000ms}.
+   *
+   * @return the timeout for failing to finish an operation.
+   */
   public Duration getOperationTimeout() {
     return operationTimeout;
   }
 
+  /**
+   * The number of background worker threads. Internally it is the number of Netty NIO threads for
+   * handling RPC events between client and Replica Servers. Defaults to {@literal 4}.
+   *
+   * @return The number of background worker threads.
+   */
   public int getAsyncWorkers() {
     return asyncWorkers;
   }
 
+  /**
+   * Whether to enable performance statistics. If true, the client will periodically report metrics
+   * to local falcon agent (currently we only support falcon as monitoring system). Defaults to
+   * {@literal false}.
+   *
+   * @return whether to enable performance statistics.
+   */
   public boolean isEnablePerfCounter() {
     return enablePerfCounter;
   }
 
+  /**
+   * Additional tags for falcon metrics. Defaults to empty string.
+   *
+   * @return additional tags for falcon metrics.
+   */
   public String getFalconPerfCounterTags() {
     return falconPerfCounterTags;
   }
 
+  /**
+   * The interval to report metrics to local falcon agent. Defaults to {@literal 10s}.
+   *
+   * @return the interval to report metrics to local falcon agent.
+   */
   public Duration getFalconPushInterval() {
     return falconPushInterval;
   }

--- a/src/main/java/com/xiaomi/infra/pegasus/client/PegasusClientFactory.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/PegasusClientFactory.java
@@ -28,8 +28,14 @@ public class PegasusClientFactory {
 
   public static PegasusClientInterface createClient(ClientOptions options) throws PException {
     Properties pegasusConfig = new Properties();
-    pegasusConfig.setProperty("meta_servers", options.metaServers);
-    pegasusConfig.setProperty("operation_timeout", String.valueOf(options.timeout));
+    pegasusConfig.setProperty("meta_servers", options.getMetaServers());
+    pegasusConfig.setProperty(
+        "operation_timeout", String.valueOf(options.getOperationTimeout().toMillis()));
+    pegasusConfig.setProperty("async_workers", String.valueOf(options.getAsyncWorkers()));
+    pegasusConfig.setProperty("enable_perf_counter", String.valueOf(options.isEnablePerfCounter()));
+    pegasusConfig.setProperty("perf_counter_tags", String.valueOf(options.isEnablePerfCounter()));
+    pegasusConfig.setProperty(
+        "push_counter_interval_secs", String.valueOf(options.getFalconPushInterval().getSeconds()));
     return new PegasusClient(pegasusConfig);
   }
 

--- a/src/main/java/com/xiaomi/infra/pegasus/client/PegasusClientFactory.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/PegasusClientFactory.java
@@ -3,6 +3,7 @@
 // can be found in the LICENSE file in the root directory of this source tree.
 package com.xiaomi.infra.pegasus.client;
 
+import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,10 +18,19 @@ public class PegasusClientFactory {
   private static String singletonClientConfigPath = null;
   private static Object singletonClientLock = new Object();
 
+  private static ClientOptions singletonClientOptions = null;
+
   // Create a client instance.
   // After used, should call client.close() to release resource.
   public static PegasusClientInterface createClient(String configPath) throws PException {
     return new PegasusClient(configPath);
+  }
+
+  public static PegasusClientInterface createClient(ClientOptions options) throws PException {
+    Properties pegasusConfig = new Properties();
+    pegasusConfig.setProperty("meta_servers", options.metaServers);
+    pegasusConfig.setProperty("operation_timeout", String.valueOf(options.timeout));
+    return new PegasusClient(pegasusConfig);
   }
 
   // Get the singleton client instance with default config path of "resource:///pegasus.properties".
@@ -53,6 +63,29 @@ public class PegasusClientFactory {
                 + singletonClientConfigPath
                 + "\"");
         throw new PException("Singleton PegasusClient Config Path Conflict");
+      }
+      return singletonClient;
+    }
+  }
+
+  public static PegasusClientInterface getSingletonClient(ClientOptions options) throws PException {
+    synchronized (singletonClientLock) {
+      if (singletonClient == null) {
+        try {
+          singletonClient = (PegasusClient) createClient(options);
+          singletonClientOptions = options;
+          LOGGER.info("Create Singleton PegasusClient with options \"" + options.toString() + "\"");
+        } catch (Throwable e) {
+          throw new PException("Create Singleton PegasusClient Failed", e);
+        }
+      } else if (!singletonClientOptions.equals(options)) {
+        LOGGER.error(
+            "Singleton PegasusClient options Conflict: \""
+                + options.toString()
+                + "\" VS \""
+                + singletonClientOptions.toString()
+                + "\"");
+        throw new PException("Singleton PegasusClient options Conflict");
       }
       return singletonClient;
     }

--- a/src/test/java/com/xiaomi/infra/pegasus/client/TestBasic.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/client/TestBasic.java
@@ -2338,6 +2338,7 @@ public class TestBasic {
     ClientOptions clientOptions2 =
         ClientOptions.builder()
             .metaServers("127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603")
+            .asyncWorkers(5) // default value is 4,this set different value
             .build();
     try {
       singletonClient1 = PegasusClientFactory.getSingletonClient(clientOptions2);

--- a/src/test/java/com/xiaomi/infra/pegasus/client/TestBasic.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/client/TestBasic.java
@@ -2250,4 +2250,80 @@ public class TestBasic {
 
     PegasusClientFactory.closeSingletonClient();
   }
+
+  @Test
+  public void createClient() throws PException {
+    System.out.println("test createClient with clientOptions");
+    ClientOptions clientOptions = new ClientOptions();
+    byte[] value = null;
+    // test createClient(clientOptions)
+    PegasusClientInterface client = null;
+    try {
+      client = PegasusClientFactory.createClient(clientOptions);
+      client.set("temp", "createClient".getBytes(), "0".getBytes(), "0".getBytes());
+      value = client.get("temp", "createClient".getBytes(), "0".getBytes());
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assert.assertTrue(false);
+    }
+
+    Assert.assertTrue(new String(value).equals("0"));
+
+    // test getSingletonClient(ClientOptions options)
+    PegasusClientInterface singletonClient = null;
+    try {
+      singletonClient = PegasusClientFactory.getSingletonClient(clientOptions);
+      singletonClient.set("temp", "getSingletonClient".getBytes(), "0".getBytes(), "0".getBytes());
+      value = singletonClient.get("temp", "getSingletonClient".getBytes(), "0".getBytes());
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assert.assertTrue(false);
+    }
+
+    Assert.assertTrue(new String(value).equals("0"));
+
+    // test getSingletonClient(ClientOptions options) --> same clientOptions
+    PegasusClientInterface singletonClient1 = null;
+    try {
+      singletonClient1 = PegasusClientFactory.getSingletonClient(clientOptions);
+      singletonClient1.set("temp", "getSingletonClient".getBytes(), "1".getBytes(), "1".getBytes());
+      value = singletonClient1.get("temp", "getSingletonClient".getBytes(), "1".getBytes());
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assert.assertTrue(false);
+    }
+
+    Assert.assertTrue(new String(value).equals("1"));
+    Assert.assertTrue(singletonClient1 == singletonClient);
+
+    // test getSingletonClient(ClientOptions options) --> different clientOptions,but values of
+    // clientOptions is same
+    ClientOptions clientOptions1 = new ClientOptions();
+    try {
+      singletonClient1 = PegasusClientFactory.getSingletonClient(clientOptions1);
+      singletonClient1.set("temp", "getSingletonClient".getBytes(), "2".getBytes(), "2".getBytes());
+      value = singletonClient1.get("temp", "getSingletonClient".getBytes(), "2".getBytes());
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assert.assertTrue(false);
+    }
+
+    Assert.assertTrue(new String(value).equals("2"));
+    Assert.assertTrue(singletonClient1 == singletonClient);
+
+    // test getSingletonClient(ClientOptions options) --> different clientOptions,and values of
+    // clientOptions is different
+    ClientOptions clientOptions2 = new ClientOptions();
+    clientOptions2.timeout = 10000;
+    try {
+      singletonClient1 = PegasusClientFactory.getSingletonClient(clientOptions2);
+      singletonClient1.set("temp", "getSingletonClient".getBytes(), "2".getBytes(), "2".getBytes());
+      value = singletonClient1.get("temp", "getSingletonClient".getBytes(), "2".getBytes());
+    } catch (Exception e) {
+      // if values of clientOptions is different,the code's right logic is "throw exception"
+      Assert.assertTrue(true);
+    }
+
+    PegasusClientFactory.closeSingletonClient();
+  }
 }

--- a/src/test/java/com/xiaomi/infra/pegasus/client/TestBasic.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/client/TestBasic.java
@@ -2254,71 +2254,101 @@ public class TestBasic {
   @Test
   public void createClient() throws PException {
     System.out.println("test createClient with clientOptions");
-    ClientOptions clientOptions = new ClientOptions();
+    ClientOptions clientOptions = ClientOptions.create();
     byte[] value = null;
+
     // test createClient(clientOptions)
     PegasusClientInterface client = null;
     try {
       client = PegasusClientFactory.createClient(clientOptions);
-      client.set("temp", "createClient".getBytes(), "0".getBytes(), "0".getBytes());
-      value = client.get("temp", "createClient".getBytes(), "0".getBytes());
+      client.set(
+          "temp",
+          "createClient".getBytes(),
+          "createClient_0".getBytes(),
+          "createClient_0".getBytes());
+      value = client.get("temp", "createClient".getBytes(), "createClient_0".getBytes());
     } catch (Exception e) {
       e.printStackTrace();
       Assert.assertTrue(false);
     }
 
-    Assert.assertTrue(new String(value).equals("0"));
+    Assert.assertTrue(new String(value).equals("createClient_0"));
 
     // test getSingletonClient(ClientOptions options)
     PegasusClientInterface singletonClient = null;
     try {
       singletonClient = PegasusClientFactory.getSingletonClient(clientOptions);
-      singletonClient.set("temp", "getSingletonClient".getBytes(), "0".getBytes(), "0".getBytes());
-      value = singletonClient.get("temp", "getSingletonClient".getBytes(), "0".getBytes());
+      singletonClient.set(
+          "temp",
+          "getSingletonClient".getBytes(),
+          "createClient_1".getBytes(),
+          "createClient_1".getBytes());
+      value =
+          singletonClient.get("temp", "getSingletonClient".getBytes(), "createClient_1".getBytes());
     } catch (Exception e) {
       e.printStackTrace();
       Assert.assertTrue(false);
     }
 
-    Assert.assertTrue(new String(value).equals("0"));
+    Assert.assertTrue(new String(value).equals("createClient_1"));
 
     // test getSingletonClient(ClientOptions options) --> same clientOptions
     PegasusClientInterface singletonClient1 = null;
     try {
       singletonClient1 = PegasusClientFactory.getSingletonClient(clientOptions);
-      singletonClient1.set("temp", "getSingletonClient".getBytes(), "1".getBytes(), "1".getBytes());
-      value = singletonClient1.get("temp", "getSingletonClient".getBytes(), "1".getBytes());
+      singletonClient1.set(
+          "temp",
+          "getSingletonClient".getBytes(),
+          "createClient_2".getBytes(),
+          "createClient_2".getBytes());
+      value =
+          singletonClient1.get(
+              "temp", "getSingletonClient".getBytes(), "createClient_2".getBytes());
     } catch (Exception e) {
       e.printStackTrace();
       Assert.assertTrue(false);
     }
 
-    Assert.assertTrue(new String(value).equals("1"));
+    Assert.assertTrue(new String(value).equals("createClient_2"));
     Assert.assertTrue(singletonClient1 == singletonClient);
 
     // test getSingletonClient(ClientOptions options) --> different clientOptions,but values of
     // clientOptions is same
-    ClientOptions clientOptions1 = new ClientOptions();
+    ClientOptions clientOptions1 = ClientOptions.create();
     try {
       singletonClient1 = PegasusClientFactory.getSingletonClient(clientOptions1);
-      singletonClient1.set("temp", "getSingletonClient".getBytes(), "2".getBytes(), "2".getBytes());
-      value = singletonClient1.get("temp", "getSingletonClient".getBytes(), "2".getBytes());
+      singletonClient1.set(
+          "temp",
+          "getSingletonClient".getBytes(),
+          "createClient_3".getBytes(),
+          "createClient_3".getBytes());
+      value =
+          singletonClient1.get(
+              "temp", "getSingletonClient".getBytes(), "createClient_3".getBytes());
     } catch (Exception e) {
       e.printStackTrace();
       Assert.assertTrue(false);
     }
 
-    Assert.assertTrue(new String(value).equals("2"));
+    Assert.assertTrue(new String(value).equals("createClient_3"));
     Assert.assertTrue(singletonClient1 == singletonClient);
 
     // test getSingletonClient(ClientOptions options) --> different clientOptions,and values of
     // clientOptions is different
-    ClientOptions clientOptions2 = new ClientOptions();
-    clientOptions2.timeout = 10000;
+    ClientOptions clientOptions2 =
+        ClientOptions.builder()
+            .metaServers("127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603")
+            .build();
     try {
       singletonClient1 = PegasusClientFactory.getSingletonClient(clientOptions2);
-      singletonClient1.set("temp", "getSingletonClient".getBytes(), "2".getBytes(), "2".getBytes());
-      value = singletonClient1.get("temp", "getSingletonClient".getBytes(), "2".getBytes());
+      singletonClient1.set(
+          "temp",
+          "getSingletonClient".getBytes(),
+          "createClient_4".getBytes(),
+          "createClient_4".getBytes());
+      value =
+          singletonClient1.get(
+              "temp", "getSingletonClient".getBytes(), "createClient_4".getBytes());
     } catch (Exception e) {
       // if values of clientOptions is different,the code's right logic is "throw exception"
       Assert.assertTrue(true);


### PR DESCRIPTION
添加了createClient(clientOptions) 、getSingletonClient(clientOptions)接口，使得用户可以直接传入配置参数（而不用写配置文件）就可以创建client

该功能为小米大数据临时需求。