### PR TITLE
upgrade netty version to 4.0.56.Final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
-  # - oraclejdk11
+  - openjdk8
 
 cache:
   directories:

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
-      <version>4.0.33.Final</version>
+      <version>4.0.56.Final</version>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>

--- a/scripts/format-all.sh
+++ b/scripts/format-all.sh
@@ -2,7 +2,7 @@
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 PROJECT_DIR=$(dirname "${SCRIPT_DIR}")
-cd "${PROJECT_DIR}" || exit -1
+cd "${PROJECT_DIR}" || exit 1
 
 SRC_FILES=(src/main/java/com/xiaomi/infra/pegasus/client/*.java
            src/main/java/com/xiaomi/infra/pegasus/metrics/*.java

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -4,7 +4,7 @@ set -e
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 PROJECT_DIR=$(dirname "${SCRIPT_DIR}")
-cd "${PROJECT_DIR}" || exit -1
+cd "${PROJECT_DIR}" || exit 1
 
 # lint all scripts, abort if there's any warning.
 function shellcheck_must_pass()

--- a/src/main/java/com/xiaomi/infra/pegasus/tools/FlowController.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/tools/FlowController.java
@@ -10,8 +10,14 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * <p>Usage:
  *
- * <p>FlowController cntl = new FlowController(qps); while (true) { // call getToken before
- * operation cntl.getToken(); client.set(...); } cntl.stop();
+ * <pre>{@code
+ * FlowController cntl = new FlowController(qps);
+ * while (true) {
+ *   cntl.getToken(); // call getToken before operation
+ *   client.set(...);
+ * }
+ * cntl.stop();
+ * }</pre>
  */
 public class FlowController {
 


### PR DESCRIPTION
Our user reported that 1.11.5-thrift-0.11.0-inlined occasionally hangs the thread forever, see this stack:

![webwxgetmsgimg](https://user-images.githubusercontent.com/6970676/62698573-0a814d80-ba10-11e9-8207-2f65cc3192db.jpeg) 

It seems to be the bug of netty-4.0.33 according to https://github.com/netty/netty/issues/6815.

This PR doesn't totally eliminate the potential risk of netty's bug, since our user may still depend on a lower version of netty that hides ours. A better solution is to use maven's shade plugin. I'll consider it when netty-4.0.56 cannot work.