### PR TITLE
bugfix: catch and rethrow BlockingOperationException for batchSet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: java
 
 jdk:

--- a/pom.xml
+++ b/pom.xml
@@ -88,8 +88,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.5.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <fork>true</fork>
           <verbose>true</verbose>
           <encoding>UTF-8</encoding>

--- a/src/main/java/com/xiaomi/infra/pegasus/client/FutureGroup.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/FutureGroup.java
@@ -17,17 +17,17 @@ final class FutureGroup<Result> {
     asyncTasks.add(task);
   }
 
-  void waitAllCompleteOrOneFail() throws PException {
-    waitAllCompleteOrOneFail(null);
+  void waitAllCompleteOrOneFail(int timeoutMillis) throws PException {
+    waitAllCompleteOrOneFail(null, timeoutMillis);
   }
 
   // Waits until all future tasks complete but terminate if one fails.
   // `results` is nullable
-  void waitAllCompleteOrOneFail(List<Result> results) throws PException {
+  void waitAllCompleteOrOneFail(List<Result> results, int timeoutMillis) throws PException {
     for (int i = 0; i < asyncTasks.size(); i++) {
       Future<Result> fu = asyncTasks.get(i);
       try {
-        fu.awaitUninterruptibly();
+        fu.await(timeoutMillis);
       } catch (Exception e) {
         throw new PException("async task #[" + i + "] await failed: " + e.toString());
       }

--- a/src/main/java/com/xiaomi/infra/pegasus/client/FutureGroup.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/FutureGroup.java
@@ -1,0 +1,45 @@
+// Copyright (c) 2017, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+package com.xiaomi.infra.pegasus.client;
+
+import io.netty.util.concurrent.Future;
+import java.util.ArrayList;
+import java.util.List;
+
+final class FutureGroup<Result> {
+
+  FutureGroup(int initialCapacity) {
+    asyncTasks = new ArrayList<>(initialCapacity);
+  }
+
+  public void add(Future<Result> task) {
+    asyncTasks.add(task);
+  }
+
+  void waitUntilOneInBatchComplete() throws PException {
+    waitUntilOneInBatchComplete(null);
+  }
+
+  // results is nullable
+  void waitUntilOneInBatchComplete(List<Result> results) throws PException {
+    for (int i = 0; i < asyncTasks.size(); i++) {
+      Future<Result> fu = asyncTasks.get(i);
+      try {
+        fu.awaitUninterruptibly();
+      } catch (Exception e) {
+        throw new PException("async task #[" + i + "] await failed: " + e.toString());
+      }
+      if (fu.isSuccess()) {
+        if (results != null) {
+          results.set(i, fu.getNow());
+        }
+      } else {
+        Throwable cause = fu.cause();
+        throw new PException("async task #[" + i + "] failed: " + cause.getMessage(), cause);
+      }
+    }
+  }
+
+  private List<Future<Result>> asyncTasks;
+}

--- a/src/main/java/com/xiaomi/infra/pegasus/client/FutureGroup.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/FutureGroup.java
@@ -17,12 +17,13 @@ final class FutureGroup<Result> {
     asyncTasks.add(task);
   }
 
-  void waitUntilOneInBatchComplete() throws PException {
-    waitUntilOneInBatchComplete(null);
+  void waitAllCompleteOrOneFail() throws PException {
+    waitAllCompleteOrOneFail(null);
   }
 
-  // results is nullable
-  void waitUntilOneInBatchComplete(List<Result> results) throws PException {
+  // Waits until all future tasks complete but terminate if one fails.
+  // `results` is nullable
+  void waitAllCompleteOrOneFail(List<Result> results) throws PException {
     for (int i = 0; i < asyncTasks.size(); i++) {
       Future<Result> fu = asyncTasks.get(i);
       try {

--- a/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
@@ -1165,6 +1165,7 @@ public class PegasusTable implements PegasusTableInterface {
     if (items == null) {
       throw new PException("Invalid parameter: items should not be null");
     }
+    if (timeout <= 0) timeout = defaultTimeout;
     FutureGroup<Void> group = new FutureGroup<>(items.size());
     for (SetItem i : items) {
       group.add(asyncSet(i.hashKey, i.sortKey, i.value, i.ttlSeconds, timeout));

--- a/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
@@ -11,7 +11,8 @@ import com.xiaomi.infra.pegasus.operator.*;
 import com.xiaomi.infra.pegasus.rpc.ReplicationException;
 import com.xiaomi.infra.pegasus.rpc.Table;
 import com.xiaomi.infra.pegasus.tools.Tools;
-import io.netty.util.concurrent.*;
+import io.netty.util.concurrent.DefaultPromise;
+import io.netty.util.concurrent.Future;
 import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
@@ -26,12 +27,10 @@ import org.apache.commons.lang3.tuple.Pair;
  *     <p>Implementation of {@link PegasusTableInterface}.
  */
 public class PegasusTable implements PegasusTableInterface {
-  private PegasusClient client;
   private Table table;
   private int defaultTimeout;
 
   public PegasusTable(PegasusClient client, Table table) {
-    this.client = client;
     this.table = table;
     this.defaultTimeout = table.getDefaultTimeout();
   }
@@ -92,7 +91,7 @@ public class PegasusTable implements PegasusTableInterface {
   }
 
   @Override
-  public Future<byte[]> asyncGet(byte[] hashKey, byte[] sortKey, int timeout /*ms*/) {
+  public Future<byte[]> asyncGet(byte[] hashKey, byte[] sortKey, int timeout /* ms */) {
     final DefaultPromise<byte[]> promise = table.newPromise();
     blob request = new blob(PegasusClient.generateKey(hashKey, sortKey));
     long partitionHash = table.getHash(request.data);
@@ -122,7 +121,7 @@ public class PegasusTable implements PegasusTableInterface {
 
   @Override
   public Future<Void> asyncSet(
-      byte[] hashKey, byte[] sortKey, byte[] value, int ttlSeconds, int timeout /*ms*/) {
+      byte[] hashKey, byte[] sortKey, byte[] value, int ttlSeconds, int timeout /* ms */) {
     final DefaultPromise<Void> promise = table.newPromise();
     if (value == null) {
       promise.setFailure(new PException("Invalid parameter: value should not be null"));
@@ -273,7 +272,7 @@ public class PegasusTable implements PegasusTableInterface {
       MultiGetOptions options,
       int maxFetchCount,
       int maxFetchSize,
-      int timeout /*ms*/) {
+      int timeout /* ms */) {
     final DefaultPromise<MultiGetResult> promise = table.newPromise();
     if (hashKey == null || hashKey.length == 0) {
       promise.setFailure(new PException("Invalid parameter: hashKey should not be null or empty"));
@@ -342,7 +341,7 @@ public class PegasusTable implements PegasusTableInterface {
       byte[] startSortKey,
       byte[] stopSortKey,
       MultiGetOptions options,
-      int timeout /*ms*/) {
+      int timeout /* ms */) {
     return asyncMultiGet(hashKey, startSortKey, stopSortKey, options, 100, 1000000, timeout);
   }
 
@@ -1166,18 +1165,11 @@ public class PegasusTable implements PegasusTableInterface {
     if (items == null) {
       throw new PException("Invalid parameter: items should not be null");
     }
-    List<Future<Void>> futures = new ArrayList<Future<Void>>();
+    FutureGroup<Void> group = new FutureGroup<>(items.size());
     for (SetItem i : items) {
-      futures.add(asyncSet(i.hashKey, i.sortKey, i.value, i.ttlSeconds, timeout));
+      group.add(asyncSet(i.hashKey, i.sortKey, i.value, i.ttlSeconds, timeout));
     }
-    for (int i = 0; i < items.size(); i++) {
-      Future<Void> fu = futures.get(i);
-      fu.awaitUninterruptibly();
-      if (!fu.isSuccess()) {
-        Throwable cause = fu.cause();
-        throw new PException("Set value of items[" + i + "] failed: " + cause.getMessage(), cause);
-      }
-    }
+    group.waitUntilOneInBatchComplete();
   }
 
   @Override

--- a/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
@@ -1169,7 +1169,7 @@ public class PegasusTable implements PegasusTableInterface {
     for (SetItem i : items) {
       group.add(asyncSet(i.hashKey, i.sortKey, i.value, i.ttlSeconds, timeout));
     }
-    group.waitUntilOneInBatchComplete();
+    group.waitAllCompleteOrOneFail();
   }
 
   @Override

--- a/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
@@ -1169,7 +1169,7 @@ public class PegasusTable implements PegasusTableInterface {
     for (SetItem i : items) {
       group.add(asyncSet(i.hashKey, i.sortKey, i.value, i.ttlSeconds, timeout));
     }
-    group.waitAllCompleteOrOneFail();
+    group.waitAllCompleteOrOneFail(timeout);
   }
 
   @Override

--- a/src/test/java/com/xiaomi/infra/pegasus/client/TestFutureGroup.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/client/TestFutureGroup.java
@@ -1,0 +1,67 @@
+// Copyright (c) 2017, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+package com.xiaomi.infra.pegasus.client;
+
+import io.netty.util.concurrent.Promise;
+import io.netty.util.concurrent.SingleThreadEventExecutor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestFutureGroup {
+
+  private static final class TestEventExecutor extends SingleThreadEventExecutor {
+    TestEventExecutor() {
+      super(null, Executors.defaultThreadFactory(), false);
+    }
+
+    @Override
+    protected void run() {
+      while (!confirmShutdown()) {
+        Runnable task = takeTask();
+        if (task != null) {
+          task.run();
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testBlockingOperationException() throws Exception {
+    // ensure pegasus client will throw PException when BlockingOperationException is thrown.
+
+    TestEventExecutor executor = new TestEventExecutor();
+    Promise<Void> promise = executor.newPromise();
+    AtomicBoolean executed = new AtomicBoolean(false);
+    AtomicBoolean success = new AtomicBoolean(true);
+
+    executor.execute(
+        () -> {
+          // A background thread waiting for promise to complete.
+          FutureGroup<Void> group = new FutureGroup<>(1);
+          group.add(promise);
+          try {
+            group.waitUntilOneInBatchComplete();
+          } catch (Exception e) {
+            success.set(false);
+            System.err.println("TestFutureGroup.testInterrupt: " + e.toString());
+          }
+          executed.set(true);
+        });
+
+    while (executor.pendingTasks() != 0) {
+      Thread.sleep(100);
+    }
+
+    promise.setSuccess(null);
+
+    // block until the background thread finished.
+    while (!executed.get()) {
+      Thread.sleep(100);
+    }
+
+    Assert.assertFalse(success.get());
+  }
+}

--- a/src/test/java/com/xiaomi/infra/pegasus/client/TestFutureGroup.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/client/TestFutureGroup.java
@@ -43,7 +43,7 @@ public class TestFutureGroup {
           FutureGroup<Void> group = new FutureGroup<>(1);
           group.add(promise);
           try {
-            group.waitAllCompleteOrOneFail();
+            group.waitAllCompleteOrOneFail(10000);
           } catch (PException e) {
             success.set(false);
             System.err.println("TestFutureGroup.testInterrupt: " + e.toString());

--- a/src/test/java/com/xiaomi/infra/pegasus/client/TestFutureGroup.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/client/TestFutureGroup.java
@@ -44,7 +44,7 @@ public class TestFutureGroup {
           group.add(promise);
           try {
             group.waitAllCompleteOrOneFail();
-          } catch (Exception e) {
+          } catch (PException e) {
             success.set(false);
             System.err.println("TestFutureGroup.testInterrupt: " + e.toString());
           }

--- a/src/test/java/com/xiaomi/infra/pegasus/client/TestFutureGroup.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/client/TestFutureGroup.java
@@ -43,7 +43,7 @@ public class TestFutureGroup {
           FutureGroup<Void> group = new FutureGroup<>(1);
           group.add(promise);
           try {
-            group.waitUntilOneInBatchComplete();
+            group.waitAllCompleteOrOneFail();
           } catch (Exception e) {
             success.set(false);
             System.err.println("TestFutureGroup.testInterrupt: " + e.toString());


### PR DESCRIPTION
The user's bug of https://github.com/XiaoMi/pegasus-java-client/pull/50 still remains and it seems not a netty's bug.

![image](https://user-images.githubusercontent.com/6970676/63153309-97478f00-c040-11e9-86df-2d0c845eabec.png)

I suspect it was due to some sort of deadlock or broken RPC that makes `Future.awaitUninterruptibly` waiting.

The bug is unknown, but some improvements may still help:

- Rethrow `BlockingOperationException` (a try/catch block wraps around `future.await`) if user thread is in the same eventloop with netty. This is hardly a possible situation but may increase our robustness.

- Use `await(timeoutMillis)` instead of `awaitUninterruptibly` to prevent the case we are unknown where the user's RPC is always incomplete but timeout is expired.
