### PR TITLE
fix: handle case where Future.cause() is null in FutureGroup

### DIFF
--- a/carrot
+++ b/carrot
@@ -72,7 +72,7 @@ function java_client_get_next_version()
     esac
 
     if [ ${versions[2]} == "SNAPSHOT" ]; then
-        echo ${versions[0]}.${versions[1]}.SNAPSHOT-$staging_branch
+        echo ${versions[0]}.${versions[1]}-$staging_branch-SNAPSHOT
     else
         echo ${versions[0]}.${versions[1]}.${versions[2]}-$staging_branch
     fi
@@ -282,7 +282,6 @@ function release_minor
     carrot_execute "mvn versions:set -DnewVersion=$new_version"
     carrot_execute "mvn versions:commit"
     carrot_execute "git commit -am \"Bump version to $new_version\""
-    carrot_execute "git push -u origin $this_branch"
 }
 
 function usage_carrot

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.xiaomi.infra</groupId>
   <artifactId>pegasus-client</artifactId>
   <packaging>jar</packaging>
-  <version>1.12.SNAPSHOT-thrift-0.11.0-inlined</version>
+  <version>1.12-thrift-0.11.0-inlined-SNAPSHOT</version>
   <name>Pegasus Java Client</name>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.xiaomi.infra</groupId>
   <artifactId>pegasus-client</artifactId>
   <packaging>jar</packaging>
-  <version>1.12.SNAPSHOT-thrift-0.11.0-inline</version>
+  <version>1.12.SNAPSHOT-thrift-0.11.0-inlined</version>
   <name>Pegasus Java Client</name>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.xiaomi.infra</groupId>
   <artifactId>pegasus-client</artifactId>
   <packaging>jar</packaging>
-  <version>1.13.SNAPSHOT-thrift-0.11.0-inlined</version>
+  <version>1.13-thrift-0.11.0-inlined-SNAPSHOT</version>
   <name>Pegasus Java Client</name>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.xiaomi.infra</groupId>
   <artifactId>pegasus-client</artifactId>
   <packaging>jar</packaging>
-  <version>1.12.SNAPSHOT-thrift-0.11.0-inlined</version>
+  <version>1.13.SNAPSHOT-thrift-0.11.0-inlined</version>
   <name>Pegasus Java Client</name>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.xiaomi.infra</groupId>
   <artifactId>pegasus-client</artifactId>
   <packaging>jar</packaging>
-  <version>1.13-thrift-0.11.0-inlined-SNAPSHOT</version>
+  <version>1.12.SNAPSHOT-thrift-0.11.0-inline</version>
   <name>Pegasus Java Client</name>
   <dependencies>
     <dependency>

--- a/src/main/java/com/xiaomi/infra/pegasus/client/FutureGroup.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/FutureGroup.java
@@ -40,7 +40,7 @@ final class FutureGroup<Result> {
         if (cause == null) {
           throw new PException(
               String.format(
-                  "async task #[" + i + "] failed: timeout expired ({}ms)", timeoutMillis));
+                  "async task #[" + i + "] failed: timeout expired (%dms)", timeoutMillis));
         }
         throw new PException("async task #[" + i + "] failed: " + cause.getMessage(), cause);
       }

--- a/src/main/java/com/xiaomi/infra/pegasus/client/FutureGroup.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/FutureGroup.java
@@ -37,6 +37,11 @@ final class FutureGroup<Result> {
         }
       } else {
         Throwable cause = fu.cause();
+        if (cause == null) {
+          throw new PException(
+              String.format(
+                  "async task #[" + i + "] failed: timeout expired ({}ms)", timeoutMillis));
+        }
         throw new PException("async task #[" + i + "] failed: " + cause.getMessage(), cause);
       }
     }


### PR DESCRIPTION
`waitAllCompleteOrOneFail` will throw `NullPointException` when timeout expired in current implementation. Because `Future.cause()` could be null when the result is not available in time.

This SNAPSHOT version was deployed on one of our users' environment (c3srv-xiaoai/ai_profile_data).