### PR TITLE
fix: set error to ERR_SESSION_RESET to trigger meta query while se…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ log.txt
 rolling_log/
 .vscode/
 google-java-format-*
+pegasus-*

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -36,7 +36,7 @@ if [ ! -f $PEGASUS_PKG.tar.gz ]; then
 fi
 cd $PEGASUS_PKG
 
-sed -i "s#https://github.com/xiaomi/pegasus-common/raw/master/zookeeper-3.4.6.tar.gz#https://github.com/XiaoMi/pegasus-common/releases/download/deps/zookeeper-3.4.6.tar.gz#" $PEGASUS_PKG/scripts/start_zk.sh
+sed -i "s#https://github.com/xiaomi/pegasus-common/raw/master/zookeeper-3.4.6.tar.gz#https://github.com/XiaoMi/pegasus-common/releases/download/deps/zookeeper-3.4.6.tar.gz#" scripts/start_zk.sh
 ./run.sh start_onebox -w
 cd ../
 

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -26,10 +26,15 @@ if [[ $(git status -s) ]]; then
     exit 1
 fi
 
+PEGASUS_PKG="pegasus-1.11.3-b45cb06-linux-x86_64-release"
+PEGASUS_PKG_URL="https://github.com/XiaoMi/pegasus/releases/download/v1.11.3/pegasus-1.11.3-b45cb06-linux-x86_64-release.zip"
+
 # start pegasus onebox environment
-wget https://github.com/XiaoMi/pegasus/releases/download/v1.11.3/pegasus-1.11.3-b45cb06-linux-x86_64-release.zip
-unzip pegasus-1.11.3-b45cb06-linux-x86_64-release.zip
-cd pegasus-1.11.3-b45cb06-linux-x86_64-release
+if [ ! -f $PEGASUS_PKG.zip ]; then
+    wget $PEGASUS_PKG_URL
+    unzip $PEGASUS_PKG.zip
+fi
+cd $PEGASUS_PKG
 
 ./run.sh start_onebox -w
 cd ../

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -26,13 +26,13 @@ if [[ $(git status -s) ]]; then
     exit 1
 fi
 
-PEGASUS_PKG="pegasus-1.11.3-b45cb06-linux-x86_64-release"
-PEGASUS_PKG_URL="https://github.com/XiaoMi/pegasus/releases/download/v1.11.3/pegasus-1.11.3-b45cb06-linux-x86_64-release.zip"
+PEGASUS_PKG="pegasus-tools-1.11.6-9f4e5ae-glibc2.12-release"
+PEGASUS_PKG_URL="https://github.com/XiaoMi/pegasus/releases/download/v1.11.6/pegasus-tools-1.11.6-9f4e5ae-glibc2.12-release.tar.gz"
 
 # start pegasus onebox environment
-if [ ! -f $PEGASUS_PKG.zip ]; then
+if [ ! -f $PEGASUS_PKG.tar.gz ]; then
     wget $PEGASUS_PKG_URL
-    unzip $PEGASUS_PKG.zip
+    tar xvf $PEGASUS_PKG.tar.gz
 fi
 cd $PEGASUS_PKG
 
@@ -41,7 +41,7 @@ cd ../
 
 if ! mvn clean test
 then
-    cd pegasus-1.11.3-b45cb06-linux-x86_64-release
+    cd $PEGASUS_PKG
     ./run.sh list_onebox
     exit 1
 fi

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -36,6 +36,7 @@ if [ ! -f $PEGASUS_PKG.tar.gz ]; then
 fi
 cd $PEGASUS_PKG
 
+sed -i "s#https://github.com/xiaomi/pegasus-common/raw/master/zookeeper-3.4.6.tar.gz#https://github.com/XiaoMi/pegasus-common/releases/download/deps/zookeeper-3.4.6.tar.gz#" $PEGASUS_PKG/scripts/start_zk.sh
 ./run.sh start_onebox -w
 cd ../
 

--- a/src/main/java/com/xiaomi/infra/pegasus/client/PException.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/PException.java
@@ -4,8 +4,10 @@
 package com.xiaomi.infra.pegasus.client;
 
 /**
- * @author qinzuoyan
- *     <p>Pegasus exception.
+ * The generic type of exception thrown by all of the Pegasus APIs.
+ *
+ * <p>Common strategies of handling PException include retrying, or ignoring. We recommend you to
+ * log the exception for future debugging.
  */
 public class PException extends Exception {
   private static final long serialVersionUID = 4436491238550521203L;

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/ReplicationException.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/ReplicationException.java
@@ -20,7 +20,7 @@ public class ReplicationException extends Exception {
   }
 
   public ReplicationException(error_code.error_types t, String message) {
-    super(t.name() + ": " + message);
+    super(t.name() + (message.isEmpty() ? "" : (": " + message)));
     err_type = t;
   }
 

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/ReplicaSession.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/ReplicaSession.java
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 
-/** Created by weijiesun on 17-9-13. */
 public class ReplicaSession {
   public static class RequestEntry {
     public int sequenceId;
@@ -87,7 +86,7 @@ public class ReplicaSession {
     entry.callback = callbackFunc;
     // NOTICE: must make sure the msg is put into the pendingResponse map BEFORE
     // the timer task is scheduled.
-    pendingResponse.put(new Integer(entry.sequenceId), entry);
+    pendingResponse.put(entry.sequenceId, entry);
     entry.timeoutTask = addTimer(entry.sequenceId, timeoutInMilliseconds);
     entry.timeoutMs = timeoutInMilliseconds;
 
@@ -136,7 +135,7 @@ public class ReplicaSession {
   }
 
   public RequestEntry getAndRemoveEntry(int seqID) {
-    return pendingResponse.remove(new Integer(seqID));
+    return pendingResponse.remove(seqID);
   }
 
   public final String name() {
@@ -179,7 +178,7 @@ public class ReplicaSession {
     synchronized (pendingSend) {
       while (!pendingSend.isEmpty()) {
         RequestEntry e = pendingSend.poll();
-        if (pendingResponse.get(new Integer(e.sequenceId)) != null) {
+        if (pendingResponse.get(e.sequenceId) != null) {
           write(e, newCache);
         } else {
           logger.info("{}: {} is removed from pending, perhaps timeout", name(), e.sequenceId);
@@ -221,6 +220,7 @@ public class ReplicaSession {
     }
   }
 
+  // Notify the RPC sender if failure occurred.
   private void tryNotifyWithSequenceID(int seqID, error_types errno, boolean isTimeoutTask) {
     logger.debug(
         "{}: {} is notified with error {}, isTimeoutTask {}",
@@ -228,12 +228,9 @@ public class ReplicaSession {
         seqID,
         errno.toString(),
         isTimeoutTask);
-    RequestEntry entry = pendingResponse.remove(new Integer(seqID));
+    RequestEntry entry = pendingResponse.remove(seqID);
     if (entry != null) {
       if (!isTimeoutTask) entry.timeoutTask.cancel(true);
-      entry.op.rpc_error.errno = errno;
-      entry.callback.run();
-
       if (errno == error_types.ERR_TIMEOUT) {
         long firstTs = firstRecentTimedOutMs.get();
         if (firstTs == 0) {
@@ -246,9 +243,13 @@ public class ReplicaSession {
                 "{}: actively close the session because it's not responding for {} seconds",
                 name(),
                 sessionResetTimeWindowMs / 1000);
-            closeSession();
+            closeSession(); // maybe fail when the session is already disconnected.
+            errno = error_types.ERR_SESSION_RESET;
           }
         }
+
+        entry.op.rpc_error.errno = errno;
+        entry.callback.run();
       } else {
         firstRecentTimedOutMs.set(0);
       }
@@ -284,6 +285,9 @@ public class ReplicaSession {
             });
   }
 
+  // Notify the RPC caller when times out. If the RPC finishes in time,
+  // this task will be cancelled.
+  // TODO(wutao1): call it addTimeoutTicker
   private ScheduledFuture addTimer(final int seqID, long timeoutInMillseconds) {
     return rpcGroup.schedule(
         new Runnable() {
@@ -337,7 +341,7 @@ public class ReplicaSession {
   }
 
   interface MessageResponseFilter {
-    public boolean abandonIt(error_types err, TMessage header);
+    boolean abandonIt(error_types err, TMessage header);
   }
 
   MessageResponseFilter filter = null;

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/ReplicaSession.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/ReplicaSession.java
@@ -247,12 +247,11 @@ public class ReplicaSession {
             errno = error_types.ERR_SESSION_RESET;
           }
         }
-
-        entry.op.rpc_error.errno = errno;
-        entry.callback.run();
       } else {
         firstRecentTimedOutMs.set(0);
       }
+      entry.op.rpc_error.errno = errno;
+      entry.callback.run();
     } else {
       logger.warn(
           "{}: {} is removed by others, current error {}, isTimeoutTask {}",


### PR DESCRIPTION
…ssion not responding.

## How does it work:

```
-            closeSession();
+            closeSession(); // maybe fail when the session is already disconnected.
+           errno = error_types.ERR_SESSION_RESET;
```

After close the session, we set error to ERR_SESSION_RESET, this error will definitely trigger
meta query, to update the local configuration table.

A potential problem is that every 10 seconds of continuous timeout errors will incur one meta query.
It may cause overload on meta-server. For example, when there are 100 clients concurrently loading data to Pegasus which causes many timeouts, the 100 clients will altogether request the single meta-server every 10 seconds.

In most cases, the scalability won't be a problem, but it should be awared.
