### PR TITLE
refactor: add more exception info

### DIFF
--- a/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
@@ -1657,7 +1657,7 @@ public class PegasusTable implements PegasusTableInterface {
     String header =
         "[table="
             + tableName
-            + ",operateName="
+            + ",operation="
             + operateName
             + ",replicaServer="
             + replicaServer

--- a/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
@@ -77,10 +77,10 @@ public class PegasusTable implements PegasusTableInterface {
     Table.ClientOPCallback callback =
         new Table.ClientOPCallback() {
           @Override
-          public void onCompletion(client_operator clientOP) throws PException {
+          public void onCompletion(client_operator clientOP) {
             rrdb_sortkey_count_operator op = (rrdb_sortkey_count_operator) clientOP;
             if (op.rpc_error.errno != error_code.error_types.ERR_OK) {
-              handleReplicationException(promise, op, (TableHandler) table);
+              handleReplicaException(promise, op, table, timeout);
             } else if (op.get_response().error != 0) {
               promise.setFailure(new PException("rocksdb error: " + op.get_response().error));
             } else {
@@ -104,10 +104,10 @@ public class PegasusTable implements PegasusTableInterface {
     Table.ClientOPCallback callback =
         new Table.ClientOPCallback() {
           @Override
-          public void onCompletion(client_operator clientOP) throws PException {
+          public void onCompletion(client_operator clientOP) {
             rrdb_get_operator gop = (rrdb_get_operator) clientOP;
             if (gop.rpc_error.errno != error_code.error_types.ERR_OK) {
-              handleReplicationException(promise, op, (TableHandler) table);
+              handleReplicaException(promise, op, table, timeout);
             } else if (gop.get_response().error == 1) { // rocksdb::kNotFound
               promise.setSuccess(null);
             } else if (gop.get_response().error != 0) {
@@ -143,10 +143,10 @@ public class PegasusTable implements PegasusTableInterface {
         op,
         new Table.ClientOPCallback() {
           @Override
-          public void onCompletion(client_operator clientOP) throws PException {
+          public void onCompletion(client_operator clientOP) {
             rrdb_put_operator gop = (rrdb_put_operator) clientOP;
             if (gop.rpc_error.errno != error_code.error_types.ERR_OK) {
-              handleReplicationException(promise, op, (TableHandler) table);
+              handleReplicaException(promise, op, table, timeout);
             } else if (gop.get_response().error != 0) {
               promise.setFailure(new PException("rocksdb error: " + gop.get_response().error));
             } else {
@@ -225,10 +225,10 @@ public class PegasusTable implements PegasusTableInterface {
         op,
         new Table.ClientOPCallback() {
           @Override
-          public void onCompletion(client_operator clientOP) throws PException {
+          public void onCompletion(client_operator clientOP) {
             rrdb_multi_get_operator gop = (rrdb_multi_get_operator) clientOP;
             if (gop.rpc_error.errno != error_code.error_types.ERR_OK) {
-              handleReplicationException(promise, op, (TableHandler) table);
+              handleReplicaException(promise, op, table, timeout);
             } else if (gop.get_response().error != 0 && gop.get_response().error != 7) {
               // rocksdb::Status::kOk && rocksdb::Status::kIncomplete
               promise.setFailure(new PException("rocksdb error: " + gop.get_response().error));
@@ -316,10 +316,10 @@ public class PegasusTable implements PegasusTableInterface {
         op,
         new Table.ClientOPCallback() {
           @Override
-          public void onCompletion(client_operator clientOP) throws PException {
+          public void onCompletion(client_operator clientOP) {
             rrdb_multi_get_operator gop = (rrdb_multi_get_operator) clientOP;
             if (gop.rpc_error.errno != error_code.error_types.ERR_OK) {
-              handleReplicationException(promise, op, (TableHandler) table);
+              handleReplicaException(promise, op, table, timeout);
             } else if (gop.get_response().error != 0 && gop.get_response().error != 7) {
               // rocksdb::Status::kOk && rocksdb::Status::kIncomplete
               promise.setFailure(new PException("rocksdb error: " + gop.get_response().error));
@@ -428,10 +428,10 @@ public class PegasusTable implements PegasusTableInterface {
         op,
         new Table.ClientOPCallback() {
           @Override
-          public void onCompletion(client_operator clientOP) throws PException {
+          public void onCompletion(client_operator clientOP) {
             rrdb_multi_put_operator op2 = (rrdb_multi_put_operator) clientOP;
             if (op2.rpc_error.errno != error_code.error_types.ERR_OK) {
-              handleReplicationException(promise, op, (TableHandler) table);
+              handleReplicaException(promise, op, table, timeout);
             } else if (op2.get_response().error != 0) {
               promise.setFailure(new PException("rocksdb error: " + op2.get_response().error));
             } else {
@@ -462,10 +462,10 @@ public class PegasusTable implements PegasusTableInterface {
         op,
         new Table.ClientOPCallback() {
           @Override
-          public void onCompletion(client_operator clientOP) throws PException {
+          public void onCompletion(client_operator clientOP) {
             rrdb_remove_operator op2 = (rrdb_remove_operator) clientOP;
             if (op2.rpc_error.errno != error_code.error_types.ERR_OK) {
-              handleReplicationException(promise, op, (TableHandler) table);
+              handleReplicaException(promise, op, table, timeout);
             } else if (op2.get_response().error != 0) {
               promise.setFailure(new PException("rocksdb error: " + op2.get_response().error));
             } else {
@@ -514,10 +514,10 @@ public class PegasusTable implements PegasusTableInterface {
     table.asyncOperate(
         op,
         new Table.ClientOPCallback() {
-          public void onCompletion(client_operator clientOP) throws PException {
+          public void onCompletion(client_operator clientOP) {
             rrdb_multi_remove_operator op2 = (rrdb_multi_remove_operator) clientOP;
             if (op2.rpc_error.errno != error_code.error_types.ERR_OK) {
-              handleReplicationException(promise, op, (TableHandler) table);
+              handleReplicaException(promise, op, table, timeout);
             } else if (op2.get_response().error != 0) {
               promise.setFailure(new PException("rocksdb error: " + op2.get_response().error));
             } else {
@@ -551,10 +551,10 @@ public class PegasusTable implements PegasusTableInterface {
         op,
         new Table.ClientOPCallback() {
           @Override
-          public void onCompletion(client_operator clientOP) throws PException {
+          public void onCompletion(client_operator clientOP) {
             rrdb_incr_operator op2 = (rrdb_incr_operator) clientOP;
             if (op2.rpc_error.errno != error_code.error_types.ERR_OK) {
-              handleReplicationException(promise, op, (TableHandler) table);
+              handleReplicaException(promise, op, table, timeout);
             } else if (op2.get_response().error != 0) {
               promise.setFailure(new PException("rocksdb error: " + op2.get_response().error));
             } else {
@@ -629,10 +629,10 @@ public class PegasusTable implements PegasusTableInterface {
         op,
         new Table.ClientOPCallback() {
           @Override
-          public void onCompletion(client_operator clientOP) throws PException {
+          public void onCompletion(client_operator clientOP) {
             rrdb_check_and_set_operator op2 = (rrdb_check_and_set_operator) clientOP;
             if (op2.rpc_error.errno != error_code.error_types.ERR_OK) {
-              handleReplicationException(promise, op, (TableHandler) table);
+              handleReplicaException(promise, op, table, timeout);
             } else if (op2.get_response().error != 0
                 && op2.get_response().error != 13) { // 13 : kTryAgain
               promise.setFailure(new PException("rocksdb error: " + op2.get_response().error));
@@ -713,10 +713,10 @@ public class PegasusTable implements PegasusTableInterface {
         op,
         new Table.ClientOPCallback() {
           @Override
-          public void onCompletion(client_operator clientOP) throws PException {
+          public void onCompletion(client_operator clientOP) {
             rrdb_check_and_mutate_operator op2 = (rrdb_check_and_mutate_operator) clientOP;
             if (op2.rpc_error.errno != error_code.error_types.ERR_OK) {
-              handleReplicationException(promise, op, (TableHandler) table);
+              handleReplicaException(promise, op, table, timeout);
             } else if (op2.get_response().error != 0
                 && op2.get_response().error != 13) { // 13 : kTryAgain
               promise.setFailure(new PException("rocksdb error: " + op2.get_response().error));
@@ -797,10 +797,10 @@ public class PegasusTable implements PegasusTableInterface {
         op,
         new Table.ClientOPCallback() {
           @Override
-          public void onCompletion(client_operator clientOP) throws PException {
+          public void onCompletion(client_operator clientOP) {
             rrdb_check_and_set_operator op2 = (rrdb_check_and_set_operator) clientOP;
             if (op2.rpc_error.errno != error_code.error_types.ERR_OK) {
-              handleReplicationException(promise, op, (TableHandler) table);
+              handleReplicaException(promise, op, table, timeout);
             } else if (op2.get_response().error != 0
                 && op2.get_response().error != 13) { // 13 : kTryAgain
               promise.setFailure(new PException("rocksdb error: " + op2.get_response().error));
@@ -838,10 +838,10 @@ public class PegasusTable implements PegasusTableInterface {
         op,
         new Table.ClientOPCallback() {
           @Override
-          public void onCompletion(client_operator clientOP) throws PException {
+          public void onCompletion(client_operator clientOP) {
             rrdb_ttl_operator op2 = (rrdb_ttl_operator) clientOP;
             if (op2.rpc_error.errno != error_code.error_types.ERR_OK) {
-              handleReplicationException(promise, op, (TableHandler) table);
+              handleReplicaException(promise, op, table, timeout);
             } else if (op2.get_response().error != 0 && op2.get_response().error != 1) {
               promise.setFailure(new PException("rocksdb error: " + op2.get_response().error));
             } else {
@@ -1644,26 +1644,26 @@ public class PegasusTable implements PegasusTableInterface {
     return ret;
   }
 
-  private void handleReplicationException(
-      DefaultPromise promise, client_operator op, TableHandler table) throws PException {
+  private void handleReplicaException(
+      DefaultPromise promise, client_operator op, Table table, int timeout) {
     gpid gPid = op.get_gpid();
-    String tableName = table.getTableName();
-    ReplicaConfiguration replicaConfiguration = table.getReplicaConfig(gPid.get_pidx());
+    ReplicaConfiguration replicaConfiguration =
+        ((TableHandler) table).getReplicaConfig(gPid.get_pidx());
     String replicaServer = null;
     try {
       replicaServer =
           replicaConfiguration.primary.get_ip() + ":" + replicaConfiguration.primary.get_port();
     } catch (UnknownHostException e) {
-      throw new PException(new InternalError("Get replica server address error"));
+      promise.setFailure(new PException(e));
+      return;
     }
-    String operateName = op.name();
 
     String message;
     String header =
         "[table="
-            + tableName
+            + table.getTableName()
             + ",operation="
-            + operateName
+            + op.name()
             + ",replicaServer="
             + replicaServer
             + ",gPid=("
@@ -1677,22 +1677,22 @@ public class PegasusTable implements PegasusTableInterface {
             new PException(new ReplicationException(op.rpc_error.errno, header + message)));
         break;
       case ERR_TIMEOUT:
-        message = " The operation is time out!";
+        message = " The operationTimeout is " + timeout + "ms";
         promise.setFailure(
             new PException(new ReplicationException(op.rpc_error.errno, header + message)));
         break;
       case ERR_OBJECT_NOT_FOUND:
-        message = " The replica server doesn't serve this gPid!";
+        message = " The replica server doesn't serve this partition!";
         promise.setFailure(
             new PException(new ReplicationException(op.rpc_error.errno, header + message)));
         break;
       case ERR_BUSY:
-        message = " The replica server is busy, maybe your table sets write_throttling!";
+        message = " Rate of requests exceeds the throughput limit!";
         promise.setFailure(
             new PException(new ReplicationException(op.rpc_error.errno, header + message)));
         break;
       case ERR_INVALID_STATE:
-        message = " The replica server is not primary!";
+        message = " The target replica is not primary!";
         promise.setFailure(
             new PException(new ReplicationException(op.rpc_error.errno, header + message)));
         break;

--- a/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
@@ -77,7 +77,7 @@ public class PegasusTable implements PegasusTableInterface {
     Table.ClientOPCallback callback =
         new Table.ClientOPCallback() {
           @Override
-          public void onCompletion(client_operator clientOP) throws UnknownHostException {
+          public void onCompletion(client_operator clientOP) throws PException {
             rrdb_sortkey_count_operator op = (rrdb_sortkey_count_operator) clientOP;
             if (op.rpc_error.errno != error_code.error_types.ERR_OK) {
               handleReplicationException(promise, op, (TableHandler) table);
@@ -104,7 +104,7 @@ public class PegasusTable implements PegasusTableInterface {
     Table.ClientOPCallback callback =
         new Table.ClientOPCallback() {
           @Override
-          public void onCompletion(client_operator clientOP) throws UnknownHostException {
+          public void onCompletion(client_operator clientOP) throws PException {
             rrdb_get_operator gop = (rrdb_get_operator) clientOP;
             if (gop.rpc_error.errno != error_code.error_types.ERR_OK) {
               handleReplicationException(promise, op, (TableHandler) table);
@@ -143,7 +143,7 @@ public class PegasusTable implements PegasusTableInterface {
         op,
         new Table.ClientOPCallback() {
           @Override
-          public void onCompletion(client_operator clientOP) throws UnknownHostException {
+          public void onCompletion(client_operator clientOP) throws PException {
             rrdb_put_operator gop = (rrdb_put_operator) clientOP;
             if (gop.rpc_error.errno != error_code.error_types.ERR_OK) {
               handleReplicationException(promise, op, (TableHandler) table);
@@ -225,7 +225,7 @@ public class PegasusTable implements PegasusTableInterface {
         op,
         new Table.ClientOPCallback() {
           @Override
-          public void onCompletion(client_operator clientOP) throws UnknownHostException {
+          public void onCompletion(client_operator clientOP) throws PException {
             rrdb_multi_get_operator gop = (rrdb_multi_get_operator) clientOP;
             if (gop.rpc_error.errno != error_code.error_types.ERR_OK) {
               handleReplicationException(promise, op, (TableHandler) table);
@@ -316,7 +316,7 @@ public class PegasusTable implements PegasusTableInterface {
         op,
         new Table.ClientOPCallback() {
           @Override
-          public void onCompletion(client_operator clientOP) throws UnknownHostException {
+          public void onCompletion(client_operator clientOP) throws PException {
             rrdb_multi_get_operator gop = (rrdb_multi_get_operator) clientOP;
             if (gop.rpc_error.errno != error_code.error_types.ERR_OK) {
               handleReplicationException(promise, op, (TableHandler) table);
@@ -428,7 +428,7 @@ public class PegasusTable implements PegasusTableInterface {
         op,
         new Table.ClientOPCallback() {
           @Override
-          public void onCompletion(client_operator clientOP) throws UnknownHostException {
+          public void onCompletion(client_operator clientOP) throws PException {
             rrdb_multi_put_operator op2 = (rrdb_multi_put_operator) clientOP;
             if (op2.rpc_error.errno != error_code.error_types.ERR_OK) {
               handleReplicationException(promise, op, (TableHandler) table);
@@ -462,7 +462,7 @@ public class PegasusTable implements PegasusTableInterface {
         op,
         new Table.ClientOPCallback() {
           @Override
-          public void onCompletion(client_operator clientOP) throws UnknownHostException {
+          public void onCompletion(client_operator clientOP) throws PException {
             rrdb_remove_operator op2 = (rrdb_remove_operator) clientOP;
             if (op2.rpc_error.errno != error_code.error_types.ERR_OK) {
               handleReplicationException(promise, op, (TableHandler) table);
@@ -514,7 +514,7 @@ public class PegasusTable implements PegasusTableInterface {
     table.asyncOperate(
         op,
         new Table.ClientOPCallback() {
-          public void onCompletion(client_operator clientOP) throws UnknownHostException {
+          public void onCompletion(client_operator clientOP) throws PException {
             rrdb_multi_remove_operator op2 = (rrdb_multi_remove_operator) clientOP;
             if (op2.rpc_error.errno != error_code.error_types.ERR_OK) {
               handleReplicationException(promise, op, (TableHandler) table);
@@ -551,7 +551,7 @@ public class PegasusTable implements PegasusTableInterface {
         op,
         new Table.ClientOPCallback() {
           @Override
-          public void onCompletion(client_operator clientOP) throws UnknownHostException {
+          public void onCompletion(client_operator clientOP) throws PException {
             rrdb_incr_operator op2 = (rrdb_incr_operator) clientOP;
             if (op2.rpc_error.errno != error_code.error_types.ERR_OK) {
               handleReplicationException(promise, op, (TableHandler) table);
@@ -629,7 +629,7 @@ public class PegasusTable implements PegasusTableInterface {
         op,
         new Table.ClientOPCallback() {
           @Override
-          public void onCompletion(client_operator clientOP) throws UnknownHostException {
+          public void onCompletion(client_operator clientOP) throws PException {
             rrdb_check_and_set_operator op2 = (rrdb_check_and_set_operator) clientOP;
             if (op2.rpc_error.errno != error_code.error_types.ERR_OK) {
               handleReplicationException(promise, op, (TableHandler) table);
@@ -713,7 +713,7 @@ public class PegasusTable implements PegasusTableInterface {
         op,
         new Table.ClientOPCallback() {
           @Override
-          public void onCompletion(client_operator clientOP) throws UnknownHostException {
+          public void onCompletion(client_operator clientOP) throws PException {
             rrdb_check_and_mutate_operator op2 = (rrdb_check_and_mutate_operator) clientOP;
             if (op2.rpc_error.errno != error_code.error_types.ERR_OK) {
               handleReplicationException(promise, op, (TableHandler) table);
@@ -797,7 +797,7 @@ public class PegasusTable implements PegasusTableInterface {
         op,
         new Table.ClientOPCallback() {
           @Override
-          public void onCompletion(client_operator clientOP) throws UnknownHostException {
+          public void onCompletion(client_operator clientOP) throws PException {
             rrdb_check_and_set_operator op2 = (rrdb_check_and_set_operator) clientOP;
             if (op2.rpc_error.errno != error_code.error_types.ERR_OK) {
               handleReplicationException(promise, op, (TableHandler) table);
@@ -838,7 +838,7 @@ public class PegasusTable implements PegasusTableInterface {
         op,
         new Table.ClientOPCallback() {
           @Override
-          public void onCompletion(client_operator clientOP) throws UnknownHostException {
+          public void onCompletion(client_operator clientOP) throws PException {
             rrdb_ttl_operator op2 = (rrdb_ttl_operator) clientOP;
             if (op2.rpc_error.errno != error_code.error_types.ERR_OK) {
               handleReplicationException(promise, op, (TableHandler) table);
@@ -1645,12 +1645,17 @@ public class PegasusTable implements PegasusTableInterface {
   }
 
   private void handleReplicationException(
-      DefaultPromise promise, client_operator op, TableHandler table) throws UnknownHostException {
+      DefaultPromise promise, client_operator op, TableHandler table) throws PException {
     gpid gPid = op.get_gpid();
     String tableName = table.getTableName();
     ReplicaConfiguration replicaConfiguration = table.getReplicaConfig(gPid.get_pidx());
-    String replicaServer =
-        replicaConfiguration.primary.get_ip() + ":" + replicaConfiguration.primary.get_port();
+    String replicaServer = null;
+    try {
+      replicaServer =
+          replicaConfiguration.primary.get_ip() + ":" + replicaConfiguration.primary.get_port();
+    } catch (UnknownHostException e) {
+      throw new PException(new InternalError("Get replica server address error"));
+    }
     String operateName = op.name();
 
     String message;

--- a/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
@@ -1658,7 +1658,7 @@ public class PegasusTable implements PegasusTableInterface {
       return;
     }
 
-    String message;
+    String message = "";
     String header =
         "[table="
             + table.getTableName()
@@ -1673,31 +1673,21 @@ public class PegasusTable implements PegasusTableInterface {
     switch (op.rpc_error.errno) {
       case ERR_SESSION_RESET:
         message = " The replica can't be access, please confirm the address!";
-        promise.setFailure(
-            new PException(new ReplicationException(op.rpc_error.errno, header + message)));
         break;
       case ERR_TIMEOUT:
         message = " The operationTimeout is " + timeout + "ms!";
-        promise.setFailure(
-            new PException(new ReplicationException(op.rpc_error.errno, header + message)));
         break;
       case ERR_OBJECT_NOT_FOUND:
         message = " The replica server doesn't serve this partition!";
-        promise.setFailure(
-            new PException(new ReplicationException(op.rpc_error.errno, header + message)));
         break;
       case ERR_BUSY:
         message = " Rate of requests exceeds the throughput limit!";
-        promise.setFailure(
-            new PException(new ReplicationException(op.rpc_error.errno, header + message)));
         break;
       case ERR_INVALID_STATE:
         message = " The target replica is not primary!";
-        promise.setFailure(
-            new PException(new ReplicationException(op.rpc_error.errno, header + message)));
         break;
-      default:
-        promise.setFailure(new PException(new ReplicationException(op.rpc_error.errno, header)));
     }
+    promise.setFailure(
+        new PException(new ReplicationException(op.rpc_error.errno, header + message)));
   }
 }

--- a/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
@@ -1649,7 +1649,7 @@ public class PegasusTable implements PegasusTableInterface {
     gpid gPid = op.get_gpid();
     ReplicaConfiguration replicaConfiguration =
         ((TableHandler) table).getReplicaConfig(gPid.get_pidx());
-    String replicaServer = null;
+    String replicaServer;
     try {
       replicaServer =
           replicaConfiguration.primary.get_ip() + ":" + replicaConfiguration.primary.get_port();
@@ -1666,13 +1666,13 @@ public class PegasusTable implements PegasusTableInterface {
             + op.name()
             + ",replicaServer="
             + replicaServer
-            + ",gPid=("
+            + ",gpid=("
             + gPid.toString()
             + ")"
             + "]";
     switch (op.rpc_error.errno) {
       case ERR_SESSION_RESET:
-        message = " The replica can't be access, please confirm the address!";
+        message = " Disconnected from the replica-server due to internal error!";
         break;
       case ERR_TIMEOUT:
         message = " The operationTimeout is " + timeout + "ms!";

--- a/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
@@ -1667,27 +1667,27 @@ public class PegasusTable implements PegasusTableInterface {
             + "]";
     switch (op.rpc_error.errno) {
       case ERR_SESSION_RESET:
-        message = "The replica server address is error, please confirm the address!";
+        message = " The replica can't be access, please confirm the address!";
         promise.setFailure(
             new PException(new ReplicationException(op.rpc_error.errno, header + message)));
         break;
       case ERR_TIMEOUT:
-        message = "The operation is time out!";
+        message = " The operation is time out!";
         promise.setFailure(
             new PException(new ReplicationException(op.rpc_error.errno, header + message)));
         break;
       case ERR_OBJECT_NOT_FOUND:
-        message = "The replica server doesn't serve this gPid!";
+        message = " The replica server doesn't serve this gPid!";
         promise.setFailure(
             new PException(new ReplicationException(op.rpc_error.errno, header + message)));
         break;
       case ERR_BUSY:
-        message = "The replica server is busy, maybe your table sets write_throttling!";
+        message = " The replica server is busy, maybe your table sets write_throttling!";
         promise.setFailure(
             new PException(new ReplicationException(op.rpc_error.errno, header + message)));
         break;
       case ERR_INVALID_STATE:
-        message = "The replica server is not primary!";
+        message = " The replica server is not primary!";
         promise.setFailure(
             new PException(new ReplicationException(op.rpc_error.errno, header + message)));
         break;

--- a/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
@@ -1677,7 +1677,7 @@ public class PegasusTable implements PegasusTableInterface {
             new PException(new ReplicationException(op.rpc_error.errno, header + message)));
         break;
       case ERR_TIMEOUT:
-        message = " The operationTimeout is " + timeout + "ms";
+        message = " The operationTimeout is " + timeout + "ms!";
         promise.setFailure(
             new PException(new ReplicationException(op.rpc_error.errno, header + message)));
         break;

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/TableHandler.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/TableHandler.java
@@ -16,6 +16,7 @@ import com.xiaomi.infra.pegasus.rpc.ReplicationException;
 import com.xiaomi.infra.pegasus.rpc.Table;
 import io.netty.util.concurrent.*;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -24,7 +25,7 @@ import org.slf4j.Logger;
 
 /** Created by sunweijie@xiaomi.com on 16-11-11. */
 public class TableHandler extends Table {
-  static final class ReplicaConfiguration {
+  public static final class ReplicaConfiguration {
     public gpid pid = new gpid();
     public long ballot = 0;
     public rpc_address primary = new rpc_address();
@@ -72,7 +73,7 @@ public class TableHandler extends Table {
 
     error_types err = MetaSession.getMetaServiceError(op);
     if (err != error_types.ERR_OK) {
-      throw new ReplicationException(err);
+      handleMetaException(err, mgr, name);
     }
 
     query_cfg_response resp = op.get_response();
@@ -98,7 +99,7 @@ public class TableHandler extends Table {
     lastQueryTime_ = 0;
   }
 
-  ReplicaConfiguration getReplicaConfig(int index) {
+  public ReplicaConfiguration getReplicaConfig(int index) {
     return tableConfig_.get().replicas.get(index);
   }
 
@@ -422,5 +423,26 @@ public class TableHandler extends Table {
     ClientRequestRound round =
         new ClientRequestRound(op, callback, manager_.counterEnabled(), (long) timeoutMs);
     call(round, 1);
+  }
+
+  private void handleMetaException(error_types err_type, ClusterManager mgr, String name)
+      throws ReplicationException {
+    String metaServer = Arrays.toString(mgr.getMetaList());
+    String message;
+    String header = "[metaServer=" + metaServer + ",tableName=" + name + "]";
+    switch (err_type) {
+      case ERR_OBJECT_NOT_FOUND:
+        message =
+            "The table is not existed under the meta_server, please confirm the meta_server url or table name!";
+        throw new ReplicationException(err_type, header + message);
+      case ERR_BUSY_CREATING:
+        message = "The table is creating, please wait a moment and retry it!";
+        throw new ReplicationException(err_type, header + message);
+      case ERR_BUSY_DROPPING:
+        message = "The table is dropping, please confirm the table name!";
+        throw new ReplicationException(err_type, header + message);
+      default:
+        throw new ReplicationException(err_type);
+    }
   }
 }

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/TableHandler.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/TableHandler.java
@@ -433,13 +433,13 @@ public class TableHandler extends Table {
     switch (err_type) {
       case ERR_OBJECT_NOT_FOUND:
         message =
-            "The table is not existed under the meta_server, please confirm the meta_server url or table name!";
+            " The table is not existed under the meta_server, please confirm the meta_server url or table name!";
         throw new ReplicationException(err_type, header + message);
       case ERR_BUSY_CREATING:
-        message = "The table is creating, please wait a moment and retry it!";
+        message = " The table is creating, please wait a moment and retry it!";
         throw new ReplicationException(err_type, header + message);
       case ERR_BUSY_DROPPING:
-        message = "The table is dropping, please confirm the table name!";
+        message = " The table is dropping, please confirm the table name!";
         throw new ReplicationException(err_type, header + message);
       default:
         throw new ReplicationException(err_type);

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/TableHandler.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/TableHandler.java
@@ -429,21 +429,20 @@ public class TableHandler extends Table {
   private void handleMetaException(error_types err_type, ClusterManager mgr, String name)
       throws ReplicationException {
     String metaServer = Arrays.toString(mgr.getMetaList());
-    String message;
+    String message = "";
     String header = "[metaServer=" + metaServer + ",tableName=" + name + "]";
     switch (err_type) {
       case ERR_OBJECT_NOT_FOUND:
         message =
             " No such table. Please make sure your meta addresses and table name are correct!";
-        throw new ReplicationException(err_type, header + message);
+        break;
       case ERR_BUSY_CREATING:
         message = " The table is creating, please wait a moment and retry it!";
-        throw new ReplicationException(err_type, header + message);
+        break;
       case ERR_BUSY_DROPPING:
         message = " The table is dropping, please confirm the table name!";
-        throw new ReplicationException(err_type, header + message);
-      default:
-        throw new ReplicationException(err_type);
+        break;
     }
+    throw new ReplicationException(err_type, header + message);
   }
 }

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/TableHandler.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/TableHandler.java
@@ -74,6 +74,7 @@ public class TableHandler extends Table {
     error_types err = MetaSession.getMetaServiceError(op);
     if (err != error_types.ERR_OK) {
       handleMetaException(err, mgr, name);
+      return;
     }
 
     query_cfg_response resp = op.get_response();
@@ -433,7 +434,7 @@ public class TableHandler extends Table {
     switch (err_type) {
       case ERR_OBJECT_NOT_FOUND:
         message =
-            " The table is not existed under the meta_server, please confirm the meta_server url or table name!";
+            " No such table. Please make sure your meta addresses and table name are correct!";
         throw new ReplicationException(err_type, header + message);
       case ERR_BUSY_CREATING:
         message = " The table is creating, please wait a moment and retry it!";


### PR DESCRIPTION
原有的异常信息仅给出错误码，例如ERR_OBJECT_NOT_FOUND，而没有详细的异常信息，这种错误：
1、用户不能明白具体含义
2、不利于问题追踪
该PR在抛异常处重新添加了处理异常的逻辑，细化各个错误码的具体描述，并给出必要的信息，修改过后的异常信息将类似：
```
ERR_OBJECT_NOT_FOUND: [metaServer=[127.0.0.1:34601, 127.0.0.1:34602, 127.0.0.1:34603],tableName=temps] No such table. Please make sure your meta addresses and table name are correct!!
```
```
ERR_TIMEOUT: [table=temp,operation=get,replicaServer=0.0.0.0:0,gPid=(gpid(1.4))] The operationTimeout is 1000ms!
````