### PR TITLE
feat: support resolving meta host through DNS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,17 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>commons-validator</groupId>
+      <artifactId>commons-validator</artifactId>
+      <version>1.6</version>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.24.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <version>4.0.0</version>

--- a/scripts/format-all.sh
+++ b/scripts/format-all.sh
@@ -15,6 +15,7 @@ SRC_FILES=(src/main/java/com/xiaomi/infra/pegasus/client/*.java
            src/test/java/com/xiaomi/infra/pegasus/metrics/*.java
            src/test/java/com/xiaomi/infra/pegasus/rpc/async/*.java
            src/test/java/com/xiaomi/infra/pegasus/tools/*.java
+           src/test/java/com/xiaomi/infra/pegasus/base/*.java
            )
 
 if [ ! -f "${PROJECT_DIR}"/google-java-format-1.7-all-deps.jar ]; then

--- a/src/main/java/com/xiaomi/infra/pegasus/base/rpc_address.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/base/rpc_address.java
@@ -132,33 +132,9 @@ public final class rpc_address
     return true;
   }
 
-
   public static rpc_address fromIpPort(String ipPort) {
     rpc_address addr = new rpc_address();
     return addr.fromString(ipPort) ? addr : null;
-  }
-
-  public static rpc_address[] resolveFromHostPort(String hostPort) {
-    String[] pairs = hostPort.split(":");
-    if (pairs.length != 2) {
-      return null;
-    }
-    Integer port = Integer.valueOf(pairs[1]);
-
-    try {
-      InetAddress[] resolvedAddresses = InetAddress.getAllByName(pairs[0]);
-      rpc_address[] results = new rpc_address[resolvedAddresses.length];
-      int size = 0;
-      for (InetAddress addr : resolvedAddresses) {
-        rpc_address rpcAddr = new rpc_address();
-        int ip = ByteBuffer.wrap(addr.getAddress()).order(ByteOrder.BIG_ENDIAN).getInt();
-        rpcAddr.address = ((long) ip << 32) + ((long) port << 16) + 1;
-        results[size++] = rpcAddr;
-      }
-      return results;
-    } catch (UnknownHostException e) {
-      return null;
-    }
   }
 
   /** Performs a deep copy on <i>other</i>. */

--- a/src/main/java/com/xiaomi/infra/pegasus/base/rpc_address.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/base/rpc_address.java
@@ -8,20 +8,19 @@
  */
 package com.xiaomi.infra.pegasus.base;
 
-import com.xiaomi.infra.pegasus.thrift.*;
-import com.xiaomi.infra.pegasus.thrift.async.*;
-import com.xiaomi.infra.pegasus.thrift.meta_data.*;
-import com.xiaomi.infra.pegasus.thrift.protocol.*;
-import com.xiaomi.infra.pegasus.thrift.transport.*;
+import com.xiaomi.infra.pegasus.thrift.TBase;
+import com.xiaomi.infra.pegasus.thrift.TException;
+import com.xiaomi.infra.pegasus.thrift.TFieldIdEnum;
+import com.xiaomi.infra.pegasus.thrift.meta_data.FieldMetaData;
+import com.xiaomi.infra.pegasus.thrift.protocol.TProtocol;
+import com.xiaomi.infra.pegasus.thrift.protocol.TStruct;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.Collections;
-import java.util.EnumMap;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.Map;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.*;
 
-public class rpc_address
+public final class rpc_address
     implements TBase<rpc_address, rpc_address._Fields>, java.io.Serializable, Cloneable {
   private static final TStruct STRUCT_DESC = new TStruct("rpc_address");
 
@@ -121,12 +120,9 @@ public class rpc_address
     }
 
     try {
+      // TODO(wutao1): getByName will query DNS if the given address is not valid ip:port.
       byte[] byteArray = InetAddress.getByName(pairs[0]).getAddress();
-      ip =
-          ((int) (byteArray[0] & 0xff) << 24)
-              | ((int) (byteArray[1] & 0xff) << 16)
-              | ((int) (byteArray[2] & 0xff) << 8)
-              | ((int) (byteArray[3] & 0xff));
+      ip = ByteBuffer.wrap(byteArray).order(ByteOrder.BIG_ENDIAN).getInt();
     } catch (UnknownHostException e) {
       return false;
     }
@@ -135,6 +131,36 @@ public class rpc_address
     address = ((long) ip << 32) + ((long) port << 16) + 1;
     return true;
   }
+
+
+  public static rpc_address fromIpPort(String ipPort) {
+    rpc_address addr = new rpc_address();
+    return addr.fromString(ipPort) ? addr : null;
+  }
+
+  public static rpc_address[] resolveFromHostPort(String hostPort) {
+    String[] pairs = hostPort.split(":");
+    if (pairs.length != 2) {
+      return null;
+    }
+    Integer port = Integer.valueOf(pairs[1]);
+
+    try {
+      InetAddress[] resolvedAddresses = InetAddress.getAllByName(pairs[0]);
+      rpc_address[] results = new rpc_address[resolvedAddresses.length];
+      int size = 0;
+      for (InetAddress addr : resolvedAddresses) {
+        rpc_address rpcAddr = new rpc_address();
+        int ip = ByteBuffer.wrap(addr.getAddress()).order(ByteOrder.BIG_ENDIAN).getInt();
+        rpcAddr.address = ((long) ip << 32) + ((long) port << 16) + 1;
+        results[size++] = rpcAddr;
+      }
+      return results;
+    } catch (UnknownHostException e) {
+      return null;
+    }
+  }
+
   /** Performs a deep copy on <i>other</i>. */
   public rpc_address(rpc_address other) {
     this.address = other.address;
@@ -192,10 +218,8 @@ public class rpc_address
   }
 
   public int compareTo(rpc_address other) {
-    if (!getClass().equals(other.getClass())) {
-      return getClass().getName().compareTo(other.getClass().getName());
-    }
-
+    if (address < other.address) return -1;
+    if (address > other.address) return 1;
     return 0;
   }
 

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/HostNameResolver.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/HostNameResolver.java
@@ -15,13 +15,12 @@ import java.nio.ByteOrder;
  */
 public class HostNameResolver {
 
-  public rpc_address[] resolve(String hostPort, int maxResolveCount)
-      throws IllegalArgumentException {
+  public rpc_address[] resolve(String hostPort, int retryCount) throws IllegalArgumentException {
 
     rpc_address[] rpc_addresses = null;
-    while (maxResolveCount != 0 && rpc_addresses == null) {
+    while (retryCount != 0 && rpc_addresses == null) {
       rpc_addresses = resolve(hostPort);
-      maxResolveCount--;
+      retryCount--;
     }
     return rpc_addresses;
   }

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/HostNameResolver.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/HostNameResolver.java
@@ -15,16 +15,6 @@ import java.nio.ByteOrder;
  */
 public class HostNameResolver {
 
-  public rpc_address[] resolve(String hostPort, int retryCount) throws IllegalArgumentException {
-
-    rpc_address[] rpc_addresses = null;
-    while (retryCount != 0 && rpc_addresses == null) {
-      rpc_addresses = resolve(hostPort);
-      retryCount--;
-    }
-    return rpc_addresses;
-  }
-
   public rpc_address[] resolve(String hostPort) throws IllegalArgumentException {
     String[] pairs = hostPort.split(":");
     if (pairs.length != 2) {
@@ -46,7 +36,7 @@ public class HostNameResolver {
     } catch (UnknownHostException e) {
       return null;
     } catch (NumberFormatException e) {
-      throw new NumberFormatException("Meta server port format error!");
+      throw new IllegalArgumentException("Meta server port format error!");
     }
   }
 }

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/HostNameResolver.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/HostNameResolver.java
@@ -28,11 +28,11 @@ public class HostNameResolver {
   public rpc_address[] resolve(String hostPort) throws IllegalArgumentException {
     String[] pairs = hostPort.split(":");
     if (pairs.length != 2) {
-      throw new IllegalArgumentException("Meta server host name format error");
+      throw new IllegalArgumentException("Meta server host name format error!");
     }
-    Integer port = Integer.valueOf(pairs[1]);
 
     try {
+      Integer port = Integer.valueOf(pairs[1]);
       InetAddress[] resolvedAddresses = InetAddress.getAllByName(pairs[0]);
       rpc_address[] results = new rpc_address[resolvedAddresses.length];
       int size = 0;
@@ -45,6 +45,8 @@ public class HostNameResolver {
       return results;
     } catch (UnknownHostException e) {
       return null;
+    } catch (NumberFormatException e) {
+      throw new NumberFormatException("Meta server port format error!");
     }
   }
 }

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/HostNameResolver.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/HostNameResolver.java
@@ -1,0 +1,16 @@
+// Copyright (c) 2019, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+package com.xiaomi.infra.pegasus.rpc.async;
+
+import com.xiaomi.infra.pegasus.base.rpc_address;
+
+/*
+ * Resolves host:port into a set of ip addresses.
+ * The intention of this class is to mock DNS.
+ */
+abstract class HostNameResolver {
+  rpc_address[] resolve(String hostPort) {
+    return rpc_address.resolveFromHostPort(hostPort);
+  }
+}

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/HostNameResolver.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/HostNameResolver.java
@@ -35,8 +35,6 @@ public class HostNameResolver {
       return results;
     } catch (UnknownHostException e) {
       return null;
-    } catch (NumberFormatException e) {
-      throw new IllegalArgumentException("Meta server port format error!");
     }
   }
 }

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/MetaSession.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/MetaSession.java
@@ -244,7 +244,7 @@ public class MetaSession extends HostNameResolver {
   void resolveHost(String hostPort) throws IllegalArgumentException {
     rpc_address[] addrs = resolve(hostPort);
     if (addrs == null) {
-      logger.error("failed to resolve address \"{}\" as host:port", hostPort);
+      logger.error("failed to resolve address {} as host:port", hostPort);
       return;
     }
 

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/MetaSession.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/MetaSession.java
@@ -9,31 +9,40 @@ import com.xiaomi.infra.pegasus.operator.client_operator;
 import com.xiaomi.infra.pegasus.operator.query_cfg_operator;
 import com.xiaomi.infra.pegasus.replication.partition_configuration;
 import io.netty.channel.EventLoopGroup;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.validator.routines.InetAddressValidator;
 
-/** Created by weijiesun on 17-9-13. */
-public class MetaSession {
+public class MetaSession extends HostNameResolver {
   public MetaSession(
       ClusterManager manager,
-      String addrList[],
+      String[] addrList,
       int eachQueryTimeoutInMills,
       int defaultMaxQueryCount,
       EventLoopGroup g)
       throws IllegalArgumentException {
     clusterManager = manager;
     metaList = new ArrayList<ReplicaSession>();
-    for (String addr : addrList) {
-      rpc_address rpc_addr = new rpc_address();
-      if (rpc_addr.fromString(addr)) {
-        logger.info("add {} as meta server", addr);
-        metaList.add(clusterManager.getReplicaSession(rpc_addr));
-      } else {
-        logger.error("invalid address {}", addr);
+
+    if (addrList.length == 1 && !InetAddressValidator.getInstance().isValid(addrList[0])) {
+      // if the given string is not a valid ip address,
+      // then take it as a hostname for a try.
+      resolveHost(addrList[0]);
+      if (!metaList.isEmpty()) {
+        hostPort = addrList[0];
+      }
+    } else {
+      for (String addr : addrList) {
+        rpc_address rpcAddr = new rpc_address();
+        if (rpcAddr.fromString(addr)) {
+          logger.info("add {} as meta server", addr);
+          metaList.add(clusterManager.getReplicaSession(rpcAddr));
+        } else {
+          logger.error("invalid address {}", addr);
+        }
       }
     }
     if (metaList.isEmpty()) {
@@ -46,13 +55,13 @@ public class MetaSession {
     this.group = g;
   }
 
-  public static final error_types getMetaServiceError(client_operator metaQueryOp) {
+  public static error_types getMetaServiceError(client_operator metaQueryOp) {
     if (metaQueryOp.rpc_error.errno != error_types.ERR_OK) return metaQueryOp.rpc_error.errno;
     query_cfg_operator op = (query_cfg_operator) metaQueryOp;
     return op.get_response().getErr().errno;
   }
 
-  public static final rpc_address getMetaServiceForwardAddress(client_operator metaQueryOp) {
+  public static rpc_address getMetaServiceForwardAddress(client_operator metaQueryOp) {
     if (metaQueryOp.rpc_error.errno != error_types.ERR_OK) return null;
     query_cfg_operator op = (query_cfg_operator) metaQueryOp;
     if (op.get_response().getErr().errno != error_types.ERR_FORWARD_TO_OTHERS) return null;
@@ -104,7 +113,7 @@ public class MetaSession {
     }
   }
 
-  private final void asyncCall(final MetaRequestRound round) {
+  private void asyncCall(final MetaRequestRound round) {
     round.lastSession.asyncSend(
         round.op,
         new Runnable() {
@@ -116,7 +125,7 @@ public class MetaSession {
         eachQueryTimeoutInMills);
   }
 
-  private final void onFinishQueryMeta(final MetaRequestRound round) {
+  void onFinishQueryMeta(final MetaRequestRound round) {
     client_operator op = round.op;
 
     boolean needDelay = false;
@@ -177,6 +186,11 @@ public class MetaSession {
           }
         } else if (metaList.get(curLeader) == round.lastSession) {
           curLeader = (curLeader + 1) % metaList.size();
+
+          // try refresh the meta list from DNS
+          if (curLeader == 0 && hostPort != null) {
+            resolveHost(hostPort);
+          }
         }
       }
       round.lastSession = metaList.get(curLeader);
@@ -187,6 +201,10 @@ public class MetaSession {
       return;
     }
 
+    retryQueryMeta(round, needDelay);
+  }
+
+  void retryQueryMeta(final MetaRequestRound round, boolean needDelay) {
     group.schedule(
         new Runnable() {
           @Override
@@ -198,7 +216,7 @@ public class MetaSession {
         TimeUnit.SECONDS);
   }
 
-  private static final class MetaRequestRound {
+  static final class MetaRequestRound {
     public client_operator op;
     public Runnable callbackFunc;
     public int maxQueryCount;
@@ -212,12 +230,61 @@ public class MetaSession {
     }
   }
 
+  /*
+   * Resolves hostname:port into a set of ip addresses.
+   */
+  void resolveHost(String hostPort) {
+    rpc_address[] addrs = resolve(hostPort);
+    if (addrs == null) {
+      logger.error("failed to resolve address \"{}\" as host:port", hostPort);
+      return;
+    }
+
+    Set<rpc_address> newSet = new TreeSet<rpc_address>(Arrays.asList(addrs));
+    Set<rpc_address> oldSet = new TreeSet<rpc_address>();
+    for (ReplicaSession meta : metaList) {
+      oldSet.add(meta.getAddress());
+    }
+
+    // fast path: do nothing if meta list is unchanged.
+    if (newSet.equals(oldSet)) {
+      return;
+    }
+
+    // removed metas
+    Set<rpc_address> removed = new HashSet<rpc_address>(oldSet);
+    removed.removeAll(newSet);
+    for (rpc_address addr : removed) {
+      logger.info("meta server {} was removed", addr);
+      for (int i = 0; i < metaList.size(); i++) {
+        if (metaList.get(i).getAddress().equals(addr)) {
+          ReplicaSession session = metaList.remove(i);
+          session.closeSession();
+        }
+      }
+    }
+
+    // newly added metas
+    Set<rpc_address> added = new HashSet<rpc_address>(newSet);
+    added.removeAll(oldSet);
+    for (rpc_address addr : added) {
+      metaList.add(clusterManager.getReplicaSession(addr));
+      logger.info("add {} as meta server", addr);
+    }
+  }
+
+  // Only for test.
+  List<ReplicaSession> getMetaList() {
+    return metaList;
+  }
+
   private ClusterManager clusterManager;
   private List<ReplicaSession> metaList;
   private int curLeader;
   private int eachQueryTimeoutInMills;
   private int defaultMaxQueryCount;
   private EventLoopGroup group;
+  private String hostPort;
 
   private static final org.slf4j.Logger logger =
       org.slf4j.LoggerFactory.getLogger(MetaSession.class);

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/MetaSession.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/MetaSession.java
@@ -240,7 +240,7 @@ public class MetaSession extends HostNameResolver {
    * Resolves hostname:port into a set of ip addresses.
    */
   void resolveHost(String hostPort) throws IllegalArgumentException {
-    rpc_address[] addrs = resolve(hostPort, 2);
+    rpc_address[] addrs = resolve(hostPort);
     if (addrs == null) {
       logger.error("failed to resolve address \"{}\" as host:port", hostPort);
       return;

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/MetaSession.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/MetaSession.java
@@ -244,7 +244,7 @@ public class MetaSession extends HostNameResolver {
   void resolveHost(String hostPort) throws IllegalArgumentException {
     rpc_address[] addrs = resolve(hostPort);
     if (addrs == null) {
-      logger.error("failed to resolve address {} as host:port", hostPort);
+      logger.error("failed to resolve address \"{}\" into ip addresses", hostPort);
       return;
     }
 

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/MetaSession.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/MetaSession.java
@@ -230,10 +230,10 @@ public class MetaSession extends HostNameResolver {
     public int maxQueryCount;
     public ReplicaSession lastSession;
 
-    public MetaRequestRound(client_operator o, Runnable r, int c, ReplicaSession l) {
+    public MetaRequestRound(client_operator o, Runnable r, int q, ReplicaSession l) {
       op = o;
       callbackFunc = r;
-      maxQueryCount = c;
+      maxQueryCount = q;
       lastSession = l;
     }
   }

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/MetaSession.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/MetaSession.java
@@ -77,8 +77,6 @@ public class MetaSession extends HostNameResolver {
     if (maxQueryCount == 0) {
       maxQueryCount = defaultMaxQueryCount;
     }
-    this.maxQueryCount = maxQueryCount;
-    this.maxResolveCount = maxResolveCount;
     MetaRequestRound round;
     synchronized (this) {
       round =
@@ -194,7 +192,7 @@ public class MetaSession extends HostNameResolver {
           // try refresh the meta list from DNS
           if (curLeader == 0 && hostPort != null && round.maxResolveCount != 0) {
             round.maxResolveCount--;
-            round.maxQueryCount = maxQueryCount;
+            round.maxQueryCount = (metaList.size() * 2 - 1);
             resolveHost(hostPort);
           }
         }
@@ -286,11 +284,6 @@ public class MetaSession extends HostNameResolver {
     return metaList;
   }
 
-  // only for test
-  void setMaxQueryCount(int count) {
-    this.maxQueryCount = count;
-  }
-
   private ClusterManager clusterManager;
   private List<ReplicaSession> metaList;
   private int curLeader;
@@ -298,8 +291,6 @@ public class MetaSession extends HostNameResolver {
   private int defaultMaxQueryCount;
   private EventLoopGroup group;
   private String hostPort;
-  private int maxQueryCount;
-  private int maxResolveCount;
 
   private static final org.slf4j.Logger logger =
       org.slf4j.LoggerFactory.getLogger(MetaSession.class);

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/ReplicaSession.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/ReplicaSession.java
@@ -124,6 +124,9 @@ public class ReplicaSession {
     VolatileFields f = fields;
     if (f.state == ConnState.CONNECTED && f.nettyChannel != null) {
       try {
+        // close().sync() means calling system API `close()` synchronously,
+        // but the connection may not be completely closed then, that is,
+        // the state may not be marked as DISCONNECTED immediately.
         f.nettyChannel.close().sync();
         logger.info("channel to {} closed", address.toString());
       } catch (Exception ex) {
@@ -146,7 +149,7 @@ public class ReplicaSession {
     return address;
   }
 
-  private void doConnect() {
+  void doConnect() {
     try {
       // we will receive the channel connect event in DefaultHandler.ChannelActive
       boot.connect(address.get_ip(), address.get_port())

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/TableHandler.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/TableHandler.java
@@ -396,7 +396,6 @@ public class TableHandler extends Table {
     } catch (ExecutionException e) {
       logger.info("got exception: " + e);
       throw new ReplicationException(e);
-
     } catch (TimeoutException e) {
       op.rpc_error.errno = error_types.ERR_TIMEOUT;
     }

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/TableHandler.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/TableHandler.java
@@ -69,7 +69,7 @@ public class TableHandler extends Table {
     query_cfg_request req = new query_cfg_request(name, new ArrayList<Integer>());
     query_cfg_operator op = new query_cfg_operator(new gpid(-1, -1), req);
 
-    mgr.getMetaSession().query(op, (mgr.getMetaList().length * 2 - 1), 2);
+    mgr.getMetaSession().query(op, 5, 2);
 
     error_types err = MetaSession.getMetaServiceError(op);
     if (err != error_types.ERR_OK) {

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/TableHandler.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/TableHandler.java
@@ -69,7 +69,7 @@ public class TableHandler extends Table {
     query_cfg_request req = new query_cfg_request(name, new ArrayList<Integer>());
     query_cfg_operator op = new query_cfg_operator(new gpid(-1, -1), req);
 
-    mgr.getMetaSession().query(op, 5);
+    mgr.getMetaSession().query(op, (mgr.getMetaList().length * 2 - 1), 2);
 
     error_types err = MetaSession.getMetaServiceError(op);
     if (err != error_types.ERR_OK) {
@@ -235,7 +235,8 @@ public class TableHandler extends Table {
                 onUpdateConfiguration(query_op);
               }
             },
-            5);
+            (manager_.getMetaList().length * 2 - 1),
+            2);
 
     return true;
   }

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/TableHandler.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/TableHandler.java
@@ -69,7 +69,7 @@ public class TableHandler extends Table {
     query_cfg_request req = new query_cfg_request(name, new ArrayList<Integer>());
     query_cfg_operator op = new query_cfg_operator(new gpid(-1, -1), req);
 
-    mgr.getMetaSession().query(op, 5, 2);
+    mgr.getMetaSession().query(op, 5);
 
     error_types err = MetaSession.getMetaServiceError(op);
     if (err != error_types.ERR_OK) {
@@ -235,8 +235,7 @@ public class TableHandler extends Table {
                 onUpdateConfiguration(query_op);
               }
             },
-            (manager_.getMetaList().length * 2 - 1),
-            2);
+            5);
 
     return true;
   }
@@ -397,6 +396,7 @@ public class TableHandler extends Table {
     } catch (ExecutionException e) {
       logger.info("got exception: " + e);
       throw new ReplicationException(e);
+
     } catch (TimeoutException e) {
       op.rpc_error.errno = error_types.ERR_TIMEOUT;
     }

--- a/src/test/java/com/xiaomi/infra/pegasus/base/TestRpcAddress.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/base/TestRpcAddress.java
@@ -4,28 +4,34 @@
 
 package com.xiaomi.infra.pegasus.base;
 
+import com.xiaomi.infra.pegasus.rpc.async.HostNameResolver;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class TestRpcAddress {
   @Test
   public void testResolveFromHostPort() throws Exception {
-    rpc_address[] addrs = rpc_address.resolveFromHostPort("127.0.0.1:34601");
+    HostNameResolver hostNameResolver = new HostNameResolver();
+    rpc_address[] addrs = hostNameResolver.resolve("127.0.0.1:34601");
 
     Assert.assertNotNull(addrs);
     Assert.assertEquals(addrs.length, 1);
     Assert.assertEquals(addrs[0].get_ip(), "127.0.0.1");
     Assert.assertEquals(addrs[0].get_port(), 34601);
 
-    addrs = rpc_address.resolveFromHostPort("www.baidu.com:80");
+    addrs = hostNameResolver.resolve("www.baidu.com:80");
     Assert.assertNotNull(addrs);
     Assert.assertTrue(addrs.length >= 1);
 
-    addrs = rpc_address.resolveFromHostPort("abcabcabcabc:34601");
+    addrs = hostNameResolver.resolve("abcabcabcabc:34601");
     Assert.assertNull(addrs);
 
-    addrs = rpc_address.resolveFromHostPort("localhost");
-    Assert.assertNull(addrs);
+    try {
+      addrs = hostNameResolver.resolve("localhost");
+    } catch (IllegalArgumentException e) {
+      e.printStackTrace();
+      Assert.assertNull(addrs);
+    }
   }
 
   @Test

--- a/src/test/java/com/xiaomi/infra/pegasus/base/TestRpcAddress.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/base/TestRpcAddress.java
@@ -1,0 +1,38 @@
+// Copyright (c) 2019, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+package com.xiaomi.infra.pegasus.base;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestRpcAddress {
+  @Test
+  public void testResolveFromHostPort() throws Exception {
+    rpc_address[] addrs = rpc_address.resolveFromHostPort("127.0.0.1:34601");
+
+    Assert.assertNotNull(addrs);
+    Assert.assertEquals(addrs.length, 1);
+    Assert.assertEquals(addrs[0].get_ip(), "127.0.0.1");
+    Assert.assertEquals(addrs[0].get_port(), 34601);
+
+    addrs = rpc_address.resolveFromHostPort("www.baidu.com:80");
+    Assert.assertNotNull(addrs);
+    Assert.assertTrue(addrs.length >= 1);
+
+    addrs = rpc_address.resolveFromHostPort("abcabcabcabc:34601");
+    Assert.assertNull(addrs);
+
+    addrs = rpc_address.resolveFromHostPort("localhost");
+    Assert.assertNull(addrs);
+  }
+
+  @Test
+  public void testFromString() throws Exception {
+    rpc_address addr = new rpc_address();
+    Assert.assertTrue(addr.fromString("127.0.0.1:34601"));
+    Assert.assertEquals(addr.get_ip(), "127.0.0.1");
+    Assert.assertEquals(addr.get_port(), 34601);
+  }
+}

--- a/src/test/java/com/xiaomi/infra/pegasus/rpc/async/MetaSessionTest.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/rpc/async/MetaSessionTest.java
@@ -269,7 +269,7 @@ public class MetaSessionTest {
   }
 
   @Test
-  public void testDNSMetaResetMaxQueryCount() {
+  public void testDNSResetMetaMaxQueryCount() {
     ClusterManager manager =
         new ClusterManager(1000, 4, false, null, 60, new String[] {"localhost:34601"});
     MetaSession metaMock = Mockito.spy(manager.getMetaSession());

--- a/src/test/java/com/xiaomi/infra/pegasus/rpc/async/MetaSessionTest.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/rpc/async/MetaSessionTest.java
@@ -22,84 +22,76 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-/**
- * MetaSession Tester.
- *
- * @author sunweijie@xiaomi.com
- * @version 1.0
- */
 public class MetaSessionTest {
 
-  public static class TestConnect {
-    @Before
-    public void before() throws Exception {}
+  @Before
+  public void before() throws Exception {}
 
-    @After
-    public void after() throws Exception {
-      rpc_address addr = new rpc_address();
-      addr.fromString("127.0.0.1:34602");
-      Toollet.tryStartServer(addr);
+  @After
+  public void after() throws Exception {
+    rpc_address addr = new rpc_address();
+    addr.fromString("127.0.0.1:34602");
+    Toollet.tryStartServer(addr);
+  }
+
+  private static void ensureNotLeader(rpc_address addr) {
+    Toollet.closeServer(addr);
+    try {
+      Thread.sleep(1000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+    Toollet.tryStartServer(addr);
+    try {
+      Thread.sleep(1000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+  /** Method: connect() */
+  @Test
+  public void testConnect() throws Exception {
+    // test: first connect to a wrong server
+    // then it forward to the right server
+    // then the wrong server crashed
+
+    String[] addr_list = {"127.0.0.1:34602", "127.0.0.1:34603", "127.0.0.1:34601"};
+    ClusterManager manager = new ClusterManager(1000, 4, false, null, 60, addr_list);
+    MetaSession session = manager.getMetaSession();
+
+    rpc_address addr = new rpc_address();
+    addr.fromString("127.0.0.1:34602");
+    ensureNotLeader(addr);
+
+    ArrayList<FutureTask<Void>> callbacks = new ArrayList<FutureTask<Void>>();
+    for (int i = 0; i < 1000; ++i) {
+      query_cfg_request req = new query_cfg_request("temp", new ArrayList<Integer>());
+      final client_operator op = new query_cfg_operator(new gpid(-1, -1), req);
+      FutureTask<Void> callback =
+          new FutureTask<Void>(
+              new Callable<Void>() {
+                @Override
+                public Void call() throws Exception {
+                  Assert.assertEquals(error_code.error_types.ERR_OK, op.rpc_error.errno);
+                  return null;
+                }
+              });
+      callbacks.add(callback);
+      session.asyncQuery(op, callback, 10);
     }
 
-    private static void ensureNotLeader(rpc_address addr) {
-      Toollet.closeServer(addr);
+    Toollet.closeServer(addr);
+    for (FutureTask<Void> cb : callbacks) {
       try {
-        Thread.sleep(1000);
-      } catch (InterruptedException e) {
+        Tools.waitUninterruptable(cb, Integer.MAX_VALUE);
+      } catch (ExecutionException e) {
         e.printStackTrace();
-      }
-      Toollet.tryStartServer(addr);
-      try {
-        Thread.sleep(1000);
-      } catch (InterruptedException e) {
-        e.printStackTrace();
+        Assert.fail();
       }
     }
 
-    /** Method: connect() */
-    @Test
-    public void testConnect() throws Exception {
-      // test: first connect to a wrong server
-      // then it forward to the right server
-      // then the wrong server crashed
-
-      String[] addr_list = {"127.0.0.1:34602", "127.0.0.1:34603", "127.0.0.1:34601"};
-      ClusterManager manager = new ClusterManager(1000, 4, false, null, 60, addr_list);
-      MetaSession session = manager.getMetaSession();
-
-      rpc_address addr = new rpc_address();
-      addr.fromString("127.0.0.1:34602");
-      ensureNotLeader(addr);
-
-      ArrayList<FutureTask<Void>> callbacks = new ArrayList<FutureTask<Void>>();
-      for (int i = 0; i < 1000; ++i) {
-        query_cfg_request req = new query_cfg_request("temp", new ArrayList<Integer>());
-        final client_operator op = new query_cfg_operator(new gpid(-1, -1), req);
-        FutureTask<Void> callback =
-            new FutureTask<Void>(
-                new Callable<Void>() {
-                  @Override
-                  public Void call() throws Exception {
-                    Assert.assertEquals(error_code.error_types.ERR_OK, op.rpc_error.errno);
-                    return null;
-                  }
-                });
-        callbacks.add(callback);
-        session.asyncQuery(op, callback, 10);
-      }
-
-      Toollet.closeServer(addr);
-      for (FutureTask<Void> cb : callbacks) {
-        try {
-          Tools.waitUninterruptable(cb, Integer.MAX_VALUE);
-        } catch (ExecutionException e) {
-          e.printStackTrace();
-          Assert.fail();
-        }
-      }
-
-      manager.close();
-    }
+    manager.close();
   }
 
   private rpc_address[] convert(List<ReplicaSession> sessions) {

--- a/src/test/java/com/xiaomi/infra/pegasus/rpc/async/MetaSessionTest.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/rpc/async/MetaSessionTest.java
@@ -60,7 +60,7 @@ public class MetaSessionTest {
     // test: first connect to a wrong server
     // then it forward to the right server
     // then the wrong server crashed
-
+    System.out.println("test meta connection");
     String[] addr_list = {"127.0.0.1:34602", "127.0.0.1:34603", "127.0.0.1:34601"};
     ClusterManager manager = new ClusterManager(1000, 4, false, null, 60, addr_list);
     MetaSession session = manager.getMetaSession();
@@ -83,7 +83,7 @@ public class MetaSessionTest {
                 }
               });
       callbacks.add(callback);
-      session.asyncQuery(op, callback, 10);
+      session.asyncQuery(op, callback, 10, 2);
     }
 
     Toollet.closeServer(addr);
@@ -111,6 +111,7 @@ public class MetaSessionTest {
   public void testResolveHost() throws Exception {
     // ensure meta list keeps consistent with dns.
 
+    System.out.println("test resolve host");
     ClusterManager manager =
         new ClusterManager(
             1000,
@@ -143,11 +144,11 @@ public class MetaSessionTest {
     Assert.assertArrayEquals(meta.resolve("localhost:34601", 2), addrs);
     meta.resolveHost("localhost:34601");
     Assert.assertArrayEquals(convert(meta.getMetaList()), addrs);
-    // while (meta2.getState() != ReplicaSession.ConnState.DISCONNECTED) {
-    // Thread.sleep(1);
-    // }
+    while (meta2.getState() != ReplicaSession.ConnState.DISCONNECTED) {
+      Thread.sleep(1);
+    }
     // ensure MetaSession#resolveHost will close unused sessions.
-    // Assert.assertEquals(meta2.getState(), ReplicaSession.ConnState.DISCONNECTED);
+    Assert.assertEquals(meta2.getState(), ReplicaSession.ConnState.DISCONNECTED);
 
     // unchanged
     meta.resolveHost("localhost:34601");
@@ -166,6 +167,7 @@ public class MetaSessionTest {
 
   @Test
   public void testMetaAllDead() throws Exception {
+    System.out.println("test meta all dead");
     ClusterManager manager =
         new ClusterManager(1000, 4, false, null, 60, new String[] {"localhost:34601"});
     MetaSession session = manager.getMetaSession();
@@ -191,6 +193,7 @@ public class MetaSessionTest {
               public void run() {}
             },
             10,
+            2,
             meta.getMetaList().get(0));
 
     // do not retry after a failed QueryMeta.
@@ -209,6 +212,7 @@ public class MetaSessionTest {
     Integer curLeader = (Integer) FieldUtils.readField(meta, "curLeader", true);
     Assert.assertEquals(curLeader.intValue(), 1);
 
+    meta.setMaxQueryCount(round.maxQueryCount);
     // failed again
     meta.onFinishQueryMeta(round);
     // switch curLeader to 0, meta list updated
@@ -222,39 +226,8 @@ public class MetaSessionTest {
   }
 
   @Test
-  public void testMetaAllChanged() {
-    ClusterManager manager =
-        new ClusterManager(1000, 4, false, null, 60, new String[] {"localhost:34601"});
-    MetaSession metaMock = Mockito.spy(manager.getMetaSession());
-
-    rpc_address[] errorAddrs = new rpc_address[3];
-    errorAddrs[0] = rpc_address.fromIpPort("172.0.0.1:34602");
-    errorAddrs[1] = rpc_address.fromIpPort("172.0.0.1:34603");
-    errorAddrs[2] = rpc_address.fromIpPort("172.0.0.1:34601");
-
-    List<ReplicaSession> metaList = metaMock.getMetaList();
-    metaList.remove(0);
-    metaList.add(manager.getReplicaSession(errorAddrs[0]));
-    metaList.add(manager.getReplicaSession(errorAddrs[1]));
-    metaList.add(manager.getReplicaSession(errorAddrs[2]));
-
-    rpc_address[] rightAddrs = new rpc_address[3];
-    rightAddrs[0] = rpc_address.fromIpPort("127.0.0.1:34602");
-    rightAddrs[1] = rpc_address.fromIpPort("127.0.0.1:34603");
-    rightAddrs[2] = rpc_address.fromIpPort("127.0.0.1:34601");
-
-    Mockito.when(metaMock.resolve("localhost:34601", 2)).thenReturn(rightAddrs);
-
-    query_cfg_request req = new query_cfg_request("temp", new ArrayList<Integer>());
-    client_operator op = new query_cfg_operator(new gpid(-1, -1), req);
-
-    metaMock.query(op, 5);
-    error_types err = MetaSession.getMetaServiceError(op);
-    Assert.assertEquals(error_code.error_types.ERR_OK, err);
-  }
-
-  @Test
   public void testMetaForwardRealLeader() throws Exception {
+    System.out.println("test meta forward real leader");
     ClusterManager manager =
         new ClusterManager(1000, 4, false, null, 60, new String[] {"localhost:34601"});
     MetaSession session = manager.getMetaSession();
@@ -286,6 +259,7 @@ public class MetaSessionTest {
               public void run() {}
             },
             10,
+            2,
             meta.getMetaList().get(0));
 
     // do not retry after a failed QueryMeta.
@@ -301,5 +275,38 @@ public class MetaSessionTest {
     Assert.assertArrayEquals(convert(meta.getMetaList()), addrs2);
     Integer curLeader = (Integer) FieldUtils.readField(meta, "curLeader", true);
     Assert.assertEquals(curLeader.intValue(), 2);
+  }
+
+  @Test
+  public void testMetaAllChanged() {
+    System.out.println("test meta all changed and can auto fresh");
+    ClusterManager manager =
+        new ClusterManager(1000, 4, false, null, 60, new String[] {"localhost:34601"});
+    MetaSession metaMock = Mockito.spy(manager.getMetaSession());
+
+    rpc_address[] errorAddrs = new rpc_address[3];
+    errorAddrs[0] = rpc_address.fromIpPort("172.0.0.1:34602");
+    errorAddrs[1] = rpc_address.fromIpPort("172.0.0.1:34603");
+    errorAddrs[2] = rpc_address.fromIpPort("172.0.0.1:34601");
+
+    List<ReplicaSession> metaList = metaMock.getMetaList();
+    metaList.remove(0);
+    metaList.add(manager.getReplicaSession(errorAddrs[0]));
+    metaList.add(manager.getReplicaSession(errorAddrs[1]));
+    metaList.add(manager.getReplicaSession(errorAddrs[2]));
+
+    rpc_address[] rightAddrs = new rpc_address[3];
+    rightAddrs[0] = rpc_address.fromIpPort("127.0.0.1:34602");
+    rightAddrs[1] = rpc_address.fromIpPort("127.0.0.1:34603");
+    rightAddrs[2] = rpc_address.fromIpPort("127.0.0.1:34601");
+
+    Mockito.when(metaMock.resolve("localhost:34601", 2)).thenReturn(rightAddrs);
+
+    query_cfg_request req = new query_cfg_request("temp", new ArrayList<Integer>());
+    client_operator op = new query_cfg_operator(new gpid(-1, -1), req);
+
+    metaMock.query(op, 5, 2);
+    error_types err = MetaSession.getMetaServiceError(op);
+    Assert.assertEquals(error_code.error_types.ERR_OK, err);
   }
 }

--- a/src/test/java/com/xiaomi/infra/pegasus/rpc/async/MetaSessionTest.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/rpc/async/MetaSessionTest.java
@@ -3,12 +3,16 @@
 // can be found in the LICENSE file in the root directory of this source tree.
 package com.xiaomi.infra.pegasus.rpc.async;
 
-import com.xiaomi.infra.pegasus.base.*;
-import com.xiaomi.infra.pegasus.operator.*;
+import com.xiaomi.infra.pegasus.base.error_code;
+import com.xiaomi.infra.pegasus.base.gpid;
+import com.xiaomi.infra.pegasus.base.rpc_address;
+import com.xiaomi.infra.pegasus.operator.client_operator;
+import com.xiaomi.infra.pegasus.operator.query_cfg_operator;
 import com.xiaomi.infra.pegasus.replication.query_cfg_request;
 import com.xiaomi.infra.pegasus.tools.Toollet;
 import com.xiaomi.infra.pegasus.tools.Tools;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
@@ -16,6 +20,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 /**
  * MetaSession Tester.
@@ -25,73 +30,193 @@ import org.junit.Test;
  */
 public class MetaSessionTest {
 
-  @Before
-  public void before() throws Exception {}
+  public static class TestConnect {
+    @Before
+    public void before() throws Exception {}
 
-  @After
-  public void after() throws Exception {
-    rpc_address addr = new rpc_address();
-    addr.fromString("127.0.0.1:34602");
-    Toollet.tryStartServer(addr);
-  }
-
-  private static void ensureNotLeader(rpc_address addr) {
-    Toollet.closeServer(addr);
-    try {
-      Thread.sleep(1000);
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    }
-    Toollet.tryStartServer(addr);
-    try {
-      Thread.sleep(1000);
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    }
-  }
-
-  /** Method: connect() */
-  @Test
-  public void testConnect() throws Exception {
-    // test: first connect to a wrong server
-    // then it forward to the right server
-    // then the wrong server crashed
-
-    String[] addr_list = {"127.0.0.1:34602", "127.0.0.1:34603", "127.0.0.1:34601"};
-    ClusterManager manager = new ClusterManager(1000, 4, false, null, 60, addr_list);
-    MetaSession session = manager.getMetaSession();
-
-    rpc_address addr = new rpc_address();
-    addr.fromString("127.0.0.1:34602");
-    ensureNotLeader(addr);
-
-    ArrayList<FutureTask<Void>> callbacks = new ArrayList<FutureTask<Void>>();
-    for (int i = 0; i < 1000; ++i) {
-      query_cfg_request req = new query_cfg_request("temp", new ArrayList<Integer>());
-      final client_operator op = new query_cfg_operator(new gpid(-1, -1), req);
-      FutureTask<Void> callback =
-          new FutureTask<Void>(
-              new Callable<Void>() {
-                @Override
-                public Void call() throws Exception {
-                  Assert.assertEquals(error_code.error_types.ERR_OK, op.rpc_error.errno);
-                  return null;
-                }
-              });
-      callbacks.add(callback);
-      session.asyncQuery(op, callback, 10);
+    @After
+    public void after() throws Exception {
+      rpc_address addr = new rpc_address();
+      addr.fromString("127.0.0.1:34602");
+      Toollet.tryStartServer(addr);
     }
 
-    Toollet.closeServer(addr);
-    for (FutureTask<Void> cb : callbacks) {
+    private static void ensureNotLeader(rpc_address addr) {
+      Toollet.closeServer(addr);
       try {
-        Tools.waitUninterruptable(cb, Integer.MAX_VALUE);
-      } catch (ExecutionException e) {
+        Thread.sleep(1000);
+      } catch (InterruptedException e) {
         e.printStackTrace();
-        Assert.fail();
+      }
+      Toollet.tryStartServer(addr);
+      try {
+        Thread.sleep(1000);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
       }
     }
 
+    /** Method: connect() */
+    @Test
+    public void testConnect() throws Exception {
+      // test: first connect to a wrong server
+      // then it forward to the right server
+      // then the wrong server crashed
+
+      String[] addr_list = {"127.0.0.1:34602", "127.0.0.1:34603", "127.0.0.1:34601"};
+      ClusterManager manager = new ClusterManager(1000, 4, false, null, 60, addr_list);
+      MetaSession session = manager.getMetaSession();
+
+      rpc_address addr = new rpc_address();
+      addr.fromString("127.0.0.1:34602");
+      ensureNotLeader(addr);
+
+      ArrayList<FutureTask<Void>> callbacks = new ArrayList<FutureTask<Void>>();
+      for (int i = 0; i < 1000; ++i) {
+        query_cfg_request req = new query_cfg_request("temp", new ArrayList<Integer>());
+        final client_operator op = new query_cfg_operator(new gpid(-1, -1), req);
+        FutureTask<Void> callback =
+            new FutureTask<Void>(
+                new Callable<Void>() {
+                  @Override
+                  public Void call() throws Exception {
+                    Assert.assertEquals(error_code.error_types.ERR_OK, op.rpc_error.errno);
+                    return null;
+                  }
+                });
+        callbacks.add(callback);
+        session.asyncQuery(op, callback, 10);
+      }
+
+      Toollet.closeServer(addr);
+      for (FutureTask<Void> cb : callbacks) {
+        try {
+          Tools.waitUninterruptable(cb, Integer.MAX_VALUE);
+        } catch (ExecutionException e) {
+          e.printStackTrace();
+          Assert.fail();
+        }
+      }
+
+      manager.close();
+    }
+  }
+
+  private rpc_address[] convert(List<ReplicaSession> sessions) {
+    rpc_address[] results = new rpc_address[sessions.size()];
+    for (int i = 0; i < results.length; i++) {
+      results[i] = sessions.get(i).getAddress();
+    }
+    return results;
+  }
+
+  @Test
+  public void testResolveHost() throws Exception {
+    // ensure meta list keeps consistent with dns.
+
+    ClusterManager manager =
+        new ClusterManager(
+            1000,
+            4,
+            false,
+            null,
+            60,
+            new String[] {"127.0.0.1:34602", "127.0.0.1:34603", "127.0.0.1:34601"});
+    MetaSession session = manager.getMetaSession();
+    MetaSession meta = Mockito.spy(session);
+    Assert.assertEquals(meta.getMetaList().size(), 3);
+    Assert.assertEquals(
+        meta.getMetaList().get(0).getAddress(), rpc_address.fromIpPort("127.0.0.1:34602"));
+    Assert.assertEquals(
+        meta.getMetaList().get(1).getAddress(), rpc_address.fromIpPort("127.0.0.1:34603"));
+    Assert.assertEquals(
+        meta.getMetaList().get(2).getAddress(), rpc_address.fromIpPort("127.0.0.1:34601"));
+    ReplicaSession meta2 = meta.getMetaList().get(0);
+    meta2.doConnect();
+    while (meta2.getState() != ReplicaSession.ConnState.CONNECTED) {
+      Thread.sleep(1);
+    }
+    Assert.assertEquals(meta2.getState(), ReplicaSession.ConnState.CONNECTED);
+
+    // DNS refreshed
+    rpc_address[] addrs = new rpc_address[2];
+    addrs[0] = rpc_address.fromIpPort("172.0.0.1:34601");
+    addrs[1] = rpc_address.fromIpPort("172.0.0.2:34601");
+    Mockito.when(meta.resolve(("localhost:34601"))).thenReturn(addrs);
+    Assert.assertArrayEquals(meta.resolve("localhost:34601"), addrs);
+    meta.resolveHost("localhost:34601");
+    Assert.assertArrayEquals(convert(meta.getMetaList()), addrs);
+    while (meta2.getState() != ReplicaSession.ConnState.DISCONNECTED) {
+      Thread.sleep(1);
+    }
+    // ensure MetaSession#resolveHost will close unused sessions.
+    Assert.assertEquals(meta2.getState(), ReplicaSession.ConnState.DISCONNECTED);
+
+    // unchanged
+    meta.resolveHost("localhost:34601");
+    Assert.assertArrayEquals(convert(meta.getMetaList()), addrs);
+
+    // DNS refreshed
+    addrs = new rpc_address[2];
+    addrs[0] = rpc_address.fromIpPort("172.0.0.1:34601");
+    addrs[1] = rpc_address.fromIpPort("172.0.0.3:34601");
+    Mockito.when(meta.resolve(("localhost:34601"))).thenReturn(addrs);
+    meta.resolveHost("localhost:34601");
+    Assert.assertArrayEquals(convert(meta.getMetaList()), addrs);
+
     manager.close();
+  }
+
+  @Test
+  public void testMetaAllDead() throws Exception {
+    ClusterManager manager =
+        new ClusterManager(1000, 4, false, null, 60, new String[] {"localhost:34601"});
+    MetaSession session = manager.getMetaSession();
+    MetaSession meta = Mockito.spy(session);
+    // curLeader=0, hostPort="localhost:34601"
+
+    // metaList = 172.0.0.1:34601, 172.0.0.2:34601
+    rpc_address[] addrs = new rpc_address[2];
+    addrs[0] = rpc_address.fromIpPort("172.0.0.1:34601");
+    addrs[1] = rpc_address.fromIpPort("172.0.0.2:34601");
+    Mockito.when(meta.resolve(("localhost:34601"))).thenReturn(addrs);
+    meta.resolveHost("localhost:34601");
+    Assert.assertArrayEquals(convert(meta.getMetaList()), addrs);
+
+    query_cfg_request req = new query_cfg_request("temp", new ArrayList<Integer>());
+    client_operator op = new query_cfg_operator(new gpid(-1, -1), req);
+    op.rpc_error.errno = error_code.error_types.ERR_SESSION_RESET;
+    MetaSession.MetaRequestRound round =
+        new MetaSession.MetaRequestRound(
+            op,
+            new Runnable() {
+              @Override
+              public void run() {}
+            },
+            10,
+            meta.getMetaList().get(0));
+
+    // do not retry after a failed QueryMeta.
+    Mockito.doNothing().when(meta).retryQueryMeta(round, false);
+
+    // DNS updated.
+    rpc_address[] addrs2 = new rpc_address[2];
+    addrs2[0] = rpc_address.fromIpPort("172.0.0.3:34601");
+    addrs2[1] = rpc_address.fromIpPort("172.0.0.4:34601");
+    Mockito.when(meta.resolve(("localhost:34601"))).thenReturn(addrs2);
+
+    // failed to query meta
+    meta.onFinishQueryMeta(round);
+    // switch curLeader to 1, meta list unchanged.
+    Assert.assertArrayEquals(convert(meta.getMetaList()), addrs);
+
+    // failed again
+    meta.onFinishQueryMeta(round);
+    // switch curLeader to 0, meta list updated
+    Assert.assertArrayEquals(convert(meta.getMetaList()), addrs2);
+
+    // retry
+    meta.onFinishQueryMeta(round);
+    Assert.assertArrayEquals(convert(meta.getMetaList()), addrs2);
   }
 }

--- a/src/test/java/com/xiaomi/infra/pegasus/rpc/async/MetaSessionTest.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/rpc/async/MetaSessionTest.java
@@ -212,7 +212,6 @@ public class MetaSessionTest {
     Integer curLeader = (Integer) FieldUtils.readField(meta, "curLeader", true);
     Assert.assertEquals(curLeader.intValue(), 1);
 
-    meta.setMaxQueryCount(round.maxQueryCount);
     // failed again
     meta.onFinishQueryMeta(round);
     // switch curLeader to 0, meta list updated

--- a/src/test/java/com/xiaomi/infra/pegasus/rpc/async/MetaSessionTest.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/rpc/async/MetaSessionTest.java
@@ -269,7 +269,7 @@ public class MetaSessionTest {
   }
 
   @Test
-  public void testDNSMetaMaxResolveCount() {
+  public void testDNSMetaResetMaxQueryCount() {
     ClusterManager manager =
         new ClusterManager(1000, 4, false, null, 60, new String[] {"localhost:34601"});
     MetaSession metaMock = Mockito.spy(manager.getMetaSession());

--- a/src/test/java/com/xiaomi/infra/pegasus/rpc/async/MetaSessionTest.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/rpc/async/MetaSessionTest.java
@@ -63,7 +63,6 @@ public class MetaSessionTest {
     // test: first connect to a wrong server
     // then it forward to the right server
     // then the wrong server crashed
-    System.out.println("test meta connection");
     String[] addr_list = {"127.0.0.1:34602", "127.0.0.1:34603", "127.0.0.1:34601"};
     ClusterManager manager = new ClusterManager(1000, 4, false, null, 60, addr_list);
     MetaSession session = manager.getMetaSession();
@@ -113,7 +112,6 @@ public class MetaSessionTest {
   @Test
   public void testDNSResolveHost() throws Exception {
     // ensure meta list keeps consistent with dns.
-    System.out.println("test resolve host");
     ClusterManager manager =
         new ClusterManager(
             1000,
@@ -160,7 +158,6 @@ public class MetaSessionTest {
 
   @Test
   public void testDNSMetaAllDead() throws Exception {
-    System.out.println("test meta all dead");
     ClusterManager manager =
         new ClusterManager(1000, 4, false, null, 60, new String[] {"localhost:34601"});
     MetaSession session = manager.getMetaSession();
@@ -178,6 +175,7 @@ public class MetaSessionTest {
 
     query_cfg_request req = new query_cfg_request("temp", new ArrayList<Integer>());
     client_operator op = new query_cfg_operator(new gpid(-1, -1), req);
+    op.rpc_error.errno = error_code.error_types.ERR_SESSION_RESET;
     MetaSession.MetaRequestRound round =
         new MetaSession.MetaRequestRound(
             op,
@@ -219,7 +217,6 @@ public class MetaSessionTest {
 
   @Test
   public void testDNSMetaForwardRealLeader() throws Exception {
-    System.out.println("test meta forward real leader");
     ClusterManager manager =
         new ClusterManager(1000, 4, false, null, 60, new String[] {"localhost:34601"});
     MetaSession session = manager.getMetaSession();
@@ -270,7 +267,6 @@ public class MetaSessionTest {
 
   @Test
   public void testDNSMetaAllChanged1() {
-    System.out.println("test meta all changed and can auto fresh");
     ClusterManager manager =
         new ClusterManager(1000, 4, false, null, 60, new String[] {"localhost:34601"});
     MetaSession metaMock = Mockito.spy(manager.getMetaSession());
@@ -315,7 +311,6 @@ public class MetaSessionTest {
     // when trigger dns refresh, the "maxQueryCount" may change to 1,
     // the client may can't choose the right leader when the new metaList size > 1,
     // the test shows "maxQueryCount" refresh is necessary
-    System.out.println("test meta all changed and can auto fresh with \"maxQueryCount refresh\" ");
     ClusterManager manager =
         new ClusterManager(1000, 4, false, null, 60, new String[] {"localhost:34601"});
     MetaSession metaMock = Mockito.spy(manager.getMetaSession());
@@ -366,7 +361,6 @@ public class MetaSessionTest {
     // if the "maxQueryCount" refresh, the retry will not stop if the meta error,
     // so "MetaRequestRound class" add "maxResolveCount"
     // the test shows "maxResolveCount" is necessary
-    System.out.println("test meta all changed and can auto fresh with \"maxResolveCount\"");
     ClusterManager manager =
         new ClusterManager(1000, 4, false, null, 60, new String[] {"localhost:34601"});
     MetaSession metaMock = Mockito.spy(manager.getMetaSession());


### PR DESCRIPTION
该PR核心代码来源：[pull#41](https://github.com/XiaoMi/pegasus-java-client/pull/41)

该PR提供对meta域名的解析，并兼容之前的url list格式。新增的域名支持格式如下：
```
tjwqtst-staging.pegasus.hadoop.srv:34601
```
该PR新增和修改的主要地方如下：
1、添加了`HostNameResolver`用于解析host
2、在`MetaSession`初始化过程添加了meta地址格式判断，以兼容url list格式
3、在`onFinishQueryMeta`中，增加了dns自动刷新逻辑：meta url为host格式下，当metalist中所有的地址失效后，强制刷新DNS
4、在`MetaRequestRound`中添加`maxResolveCount`，以支持在DNS刷新之后依然失败的情况，启动有限次的重试

注意：DNS解析依赖DNS域名系统支持，需在域名系统中注册不同集群对应的域名，并在后续变更中手动维护