### PR TITLE
feat: add more exception info on synchronous APIs

### DIFF
--- a/src/main/java/com/xiaomi/infra/pegasus/base/error_code.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/base/error_code.java
@@ -102,6 +102,7 @@ public class error_code
 
     // ERROR_CODE defined by client
     ERR_SESSION_RESET,
+    ERR_THREAD_INTERRUPTED,
   };
 
   public error_types errno;

--- a/src/main/java/com/xiaomi/infra/pegasus/client/PException.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/PException.java
@@ -3,6 +3,9 @@
 // can be found in the LICENSE file in the root directory of this source tree.
 package com.xiaomi.infra.pegasus.client;
 
+import com.xiaomi.infra.pegasus.base.error_code;
+import com.xiaomi.infra.pegasus.rpc.ReplicationException;
+
 /**
  * The generic type of exception thrown by all of the Pegasus APIs.
  *
@@ -26,5 +29,20 @@ public class PException extends Exception {
 
   public PException(Throwable cause) {
     super(cause);
+  }
+
+  static PException threadInterrupted(String tableName) {
+    return new PException(
+        new ReplicationException(
+            error_code.error_types.ERR_THREAD_INTERRUPTED,
+            String.format("[table=%s] Thread is interrupted!", tableName)));
+  }
+
+  static PException timeout(String tableName, int timeout) {
+    return new PException(
+        new ReplicationException(
+            error_code.error_types.ERR_TIMEOUT,
+            String.format(
+                "[table=%s, timeout=%dms] Timeout on Future await!", tableName, timeout)));
   }
 }

--- a/src/main/java/com/xiaomi/infra/pegasus/client/PException.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/PException.java
@@ -5,6 +5,7 @@ package com.xiaomi.infra.pegasus.client;
 
 import com.xiaomi.infra.pegasus.base.error_code;
 import com.xiaomi.infra.pegasus.rpc.ReplicationException;
+import java.util.concurrent.TimeoutException;
 
 /**
  * The generic type of exception thrown by all of the Pegasus APIs.
@@ -31,18 +32,19 @@ public class PException extends Exception {
     super(cause);
   }
 
-  static PException threadInterrupted(String tableName) {
+  static PException threadInterrupted(String tableName, InterruptedException e) {
     return new PException(
         new ReplicationException(
             error_code.error_types.ERR_THREAD_INTERRUPTED,
-            String.format("[table=%s] Thread is interrupted!", tableName)));
+            String.format("[table=%s] Thread was interrupted: %s", tableName, e.getMessage())));
   }
 
-  static PException timeout(String tableName, int timeout) {
+  static PException timeout(String tableName, int timeout, TimeoutException e) {
     return new PException(
         new ReplicationException(
             error_code.error_types.ERR_TIMEOUT,
             String.format(
-                "[table=%s, timeout=%dms] Timeout on Future await!", tableName, timeout)));
+                "[table=%s, timeout=%dms] Timeout on Future await: %s",
+                tableName, timeout, e.getMessage())));
   }
 }

--- a/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
@@ -862,9 +862,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       return asyncExist(hashKey, sortKey, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.threadInterrupted(table.getTableName());
     } catch (TimeoutException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.timeout(table.getTableName(), timeout);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -876,9 +876,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       return asyncSortKeyCount(hashKey, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.threadInterrupted(table.getTableName());
     } catch (TimeoutException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.timeout(table.getTableName(), timeout);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -890,9 +890,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       return asyncGet(hashKey, sortKey, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.threadInterrupted(table.getTableName());
     } catch (TimeoutException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.timeout(table.getTableName(), timeout);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -969,9 +969,9 @@ public class PegasusTable implements PegasusTableInterface {
       return asyncMultiGet(hashKey, sortKeys, maxFetchCount, maxFetchSize, timeout)
           .get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.threadInterrupted(table.getTableName());
     } catch (TimeoutException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.timeout(table.getTableName(), timeout);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -984,9 +984,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       return asyncMultiGet(hashKey, sortKeys, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.threadInterrupted(table.getTableName());
     } catch (TimeoutException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.timeout(table.getTableName(), timeout);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1008,9 +1008,9 @@ public class PegasusTable implements PegasusTableInterface {
               hashKey, startSortKey, stopSortKey, options, maxFetchCount, maxFetchSize, timeout)
           .get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.threadInterrupted(table.getTableName());
     } catch (TimeoutException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.timeout(table.getTableName(), timeout);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1029,9 +1029,9 @@ public class PegasusTable implements PegasusTableInterface {
       return asyncMultiGet(hashKey, startSortKey, stopSortKey, options, timeout)
           .get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.threadInterrupted(table.getTableName());
     } catch (TimeoutException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.timeout(table.getTableName(), timeout);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1112,9 +1112,9 @@ public class PegasusTable implements PegasusTableInterface {
       return asyncMultiGetSortKeys(hashKey, maxFetchCount, maxFetchSize, timeout)
           .get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.threadInterrupted(table.getTableName());
     } catch (TimeoutException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.timeout(table.getTableName(), timeout);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1126,9 +1126,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       return asyncMultiGetSortKeys(hashKey, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.threadInterrupted(table.getTableName());
     } catch (TimeoutException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.timeout(table.getTableName(), timeout);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1141,9 +1141,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       asyncSet(hashKey, sortKey, value, ttlSeconds, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.threadInterrupted(table.getTableName());
     } catch (TimeoutException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.timeout(table.getTableName(), timeout);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1155,9 +1155,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       asyncSet(hashKey, sortKey, value, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.threadInterrupted(table.getTableName());
     } catch (TimeoutException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.timeout(table.getTableName(), timeout);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1215,9 +1215,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       asyncMultiSet(hashKey, values, ttlSeconds, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.threadInterrupted(table.getTableName());
     } catch (TimeoutException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.timeout(table.getTableName(), timeout);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1230,9 +1230,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       asyncMultiSet(hashKey, values, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.threadInterrupted(table.getTableName());
     } catch (TimeoutException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.timeout(table.getTableName(), timeout);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1298,9 +1298,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       asyncDel(hashKey, sortKey, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.threadInterrupted(table.getTableName());
     } catch (TimeoutException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.timeout(table.getTableName(), timeout);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1362,9 +1362,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       asyncMultiDel(hashKey, sortKeys, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.threadInterrupted(table.getTableName());
     } catch (TimeoutException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.timeout(table.getTableName(), timeout);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1517,9 +1517,9 @@ public class PegasusTable implements PegasusTableInterface {
       return asyncIncr(hashKey, sortKey, increment, ttlSeconds, timeout)
           .get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.threadInterrupted(table.getTableName());
     } catch (TimeoutException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.timeout(table.getTableName(), timeout);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1531,9 +1531,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       return asyncIncr(hashKey, sortKey, increment, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.threadInterrupted(table.getTableName());
     } catch (TimeoutException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.timeout(table.getTableName(), timeout);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1563,9 +1563,9 @@ public class PegasusTable implements PegasusTableInterface {
               timeout)
           .get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.threadInterrupted(table.getTableName());
     } catch (TimeoutException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.timeout(table.getTableName(), timeout);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1587,9 +1587,9 @@ public class PegasusTable implements PegasusTableInterface {
               hashKey, checkSortKey, checkType, checkOperand, mutations, options, timeout)
           .get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.threadInterrupted(table.getTableName());
     } catch (TimeoutException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.timeout(table.getTableName(), timeout);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1610,9 +1610,9 @@ public class PegasusTable implements PegasusTableInterface {
               hashKey, sortKey, expectedValue, desiredValue, ttlSeconds, timeout)
           .get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.threadInterrupted(table.getTableName());
     } catch (TimeoutException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.timeout(table.getTableName(), timeout);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1624,9 +1624,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       return asyncTTL(hashKey, sortKey, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.threadInterrupted(table.getTableName());
     } catch (TimeoutException e) {
-      throw new PException(new ReplicationException(error_code.error_types.ERR_TIMEOUT));
+      throw PException.timeout(table.getTableName(), timeout);
     } catch (ExecutionException e) {
       throw new PException(e);
     }

--- a/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
@@ -862,9 +862,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       return asyncExist(hashKey, sortKey, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw PException.threadInterrupted(table.getTableName());
+      throw PException.threadInterrupted(table.getTableName(), e);
     } catch (TimeoutException e) {
-      throw PException.timeout(table.getTableName(), timeout);
+      throw PException.timeout(table.getTableName(), timeout, e);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -876,9 +876,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       return asyncSortKeyCount(hashKey, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw PException.threadInterrupted(table.getTableName());
+      throw PException.threadInterrupted(table.getTableName(), e);
     } catch (TimeoutException e) {
-      throw PException.timeout(table.getTableName(), timeout);
+      throw PException.timeout(table.getTableName(), timeout, e);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -890,9 +890,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       return asyncGet(hashKey, sortKey, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw PException.threadInterrupted(table.getTableName());
+      throw PException.threadInterrupted(table.getTableName(), e);
     } catch (TimeoutException e) {
-      throw PException.timeout(table.getTableName(), timeout);
+      throw PException.timeout(table.getTableName(), timeout, e);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -969,9 +969,9 @@ public class PegasusTable implements PegasusTableInterface {
       return asyncMultiGet(hashKey, sortKeys, maxFetchCount, maxFetchSize, timeout)
           .get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw PException.threadInterrupted(table.getTableName());
+      throw PException.threadInterrupted(table.getTableName(), e);
     } catch (TimeoutException e) {
-      throw PException.timeout(table.getTableName(), timeout);
+      throw PException.timeout(table.getTableName(), timeout, e);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -984,9 +984,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       return asyncMultiGet(hashKey, sortKeys, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw PException.threadInterrupted(table.getTableName());
+      throw PException.threadInterrupted(table.getTableName(), e);
     } catch (TimeoutException e) {
-      throw PException.timeout(table.getTableName(), timeout);
+      throw PException.timeout(table.getTableName(), timeout, e);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1008,9 +1008,9 @@ public class PegasusTable implements PegasusTableInterface {
               hashKey, startSortKey, stopSortKey, options, maxFetchCount, maxFetchSize, timeout)
           .get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw PException.threadInterrupted(table.getTableName());
+      throw PException.threadInterrupted(table.getTableName(), e);
     } catch (TimeoutException e) {
-      throw PException.timeout(table.getTableName(), timeout);
+      throw PException.timeout(table.getTableName(), timeout, e);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1029,9 +1029,9 @@ public class PegasusTable implements PegasusTableInterface {
       return asyncMultiGet(hashKey, startSortKey, stopSortKey, options, timeout)
           .get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw PException.threadInterrupted(table.getTableName());
+      throw PException.threadInterrupted(table.getTableName(), e);
     } catch (TimeoutException e) {
-      throw PException.timeout(table.getTableName(), timeout);
+      throw PException.timeout(table.getTableName(), timeout, e);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1112,9 +1112,9 @@ public class PegasusTable implements PegasusTableInterface {
       return asyncMultiGetSortKeys(hashKey, maxFetchCount, maxFetchSize, timeout)
           .get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw PException.threadInterrupted(table.getTableName());
+      throw PException.threadInterrupted(table.getTableName(), e);
     } catch (TimeoutException e) {
-      throw PException.timeout(table.getTableName(), timeout);
+      throw PException.timeout(table.getTableName(), timeout, e);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1126,9 +1126,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       return asyncMultiGetSortKeys(hashKey, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw PException.threadInterrupted(table.getTableName());
+      throw PException.threadInterrupted(table.getTableName(), e);
     } catch (TimeoutException e) {
-      throw PException.timeout(table.getTableName(), timeout);
+      throw PException.timeout(table.getTableName(), timeout, e);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1141,9 +1141,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       asyncSet(hashKey, sortKey, value, ttlSeconds, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw PException.threadInterrupted(table.getTableName());
+      throw PException.threadInterrupted(table.getTableName(), e);
     } catch (TimeoutException e) {
-      throw PException.timeout(table.getTableName(), timeout);
+      throw PException.timeout(table.getTableName(), timeout, e);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1155,9 +1155,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       asyncSet(hashKey, sortKey, value, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw PException.threadInterrupted(table.getTableName());
+      throw PException.threadInterrupted(table.getTableName(), e);
     } catch (TimeoutException e) {
-      throw PException.timeout(table.getTableName(), timeout);
+      throw PException.timeout(table.getTableName(), timeout, e);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1215,9 +1215,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       asyncMultiSet(hashKey, values, ttlSeconds, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw PException.threadInterrupted(table.getTableName());
+      throw PException.threadInterrupted(table.getTableName(), e);
     } catch (TimeoutException e) {
-      throw PException.timeout(table.getTableName(), timeout);
+      throw PException.timeout(table.getTableName(), timeout, e);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1230,9 +1230,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       asyncMultiSet(hashKey, values, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw PException.threadInterrupted(table.getTableName());
+      throw PException.threadInterrupted(table.getTableName(), e);
     } catch (TimeoutException e) {
-      throw PException.timeout(table.getTableName(), timeout);
+      throw PException.timeout(table.getTableName(), timeout, e);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1298,9 +1298,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       asyncDel(hashKey, sortKey, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw PException.threadInterrupted(table.getTableName());
+      throw PException.threadInterrupted(table.getTableName(), e);
     } catch (TimeoutException e) {
-      throw PException.timeout(table.getTableName(), timeout);
+      throw PException.timeout(table.getTableName(), timeout, e);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1362,9 +1362,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       asyncMultiDel(hashKey, sortKeys, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw PException.threadInterrupted(table.getTableName());
+      throw PException.threadInterrupted(table.getTableName(), e);
     } catch (TimeoutException e) {
-      throw PException.timeout(table.getTableName(), timeout);
+      throw PException.timeout(table.getTableName(), timeout, e);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1517,9 +1517,9 @@ public class PegasusTable implements PegasusTableInterface {
       return asyncIncr(hashKey, sortKey, increment, ttlSeconds, timeout)
           .get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw PException.threadInterrupted(table.getTableName());
+      throw PException.threadInterrupted(table.getTableName(), e);
     } catch (TimeoutException e) {
-      throw PException.timeout(table.getTableName(), timeout);
+      throw PException.timeout(table.getTableName(), timeout, e);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1531,9 +1531,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       return asyncIncr(hashKey, sortKey, increment, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw PException.threadInterrupted(table.getTableName());
+      throw PException.threadInterrupted(table.getTableName(), e);
     } catch (TimeoutException e) {
-      throw PException.timeout(table.getTableName(), timeout);
+      throw PException.timeout(table.getTableName(), timeout, e);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1563,9 +1563,9 @@ public class PegasusTable implements PegasusTableInterface {
               timeout)
           .get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw PException.threadInterrupted(table.getTableName());
+      throw PException.threadInterrupted(table.getTableName(), e);
     } catch (TimeoutException e) {
-      throw PException.timeout(table.getTableName(), timeout);
+      throw PException.timeout(table.getTableName(), timeout, e);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1587,9 +1587,9 @@ public class PegasusTable implements PegasusTableInterface {
               hashKey, checkSortKey, checkType, checkOperand, mutations, options, timeout)
           .get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw PException.threadInterrupted(table.getTableName());
+      throw PException.threadInterrupted(table.getTableName(), e);
     } catch (TimeoutException e) {
-      throw PException.timeout(table.getTableName(), timeout);
+      throw PException.timeout(table.getTableName(), timeout, e);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1610,9 +1610,9 @@ public class PegasusTable implements PegasusTableInterface {
               hashKey, sortKey, expectedValue, desiredValue, ttlSeconds, timeout)
           .get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw PException.threadInterrupted(table.getTableName());
+      throw PException.threadInterrupted(table.getTableName(), e);
     } catch (TimeoutException e) {
-      throw PException.timeout(table.getTableName(), timeout);
+      throw PException.timeout(table.getTableName(), timeout, e);
     } catch (ExecutionException e) {
       throw new PException(e);
     }
@@ -1624,9 +1624,9 @@ public class PegasusTable implements PegasusTableInterface {
     try {
       return asyncTTL(hashKey, sortKey, timeout).get(timeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw PException.threadInterrupted(table.getTableName());
+      throw PException.threadInterrupted(table.getTableName(), e);
     } catch (TimeoutException e) {
-      throw PException.timeout(table.getTableName(), timeout);
+      throw PException.timeout(table.getTableName(), timeout, e);
     } catch (ExecutionException e) {
       throw new PException(e);
     }

--- a/src/test/java/com/xiaomi/infra/pegasus/client/TestPException.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/client/TestPException.java
@@ -1,0 +1,26 @@
+// Copyright (c) 2019, Xiaomi, Inc.  All rights reserved.
+// This source code is licensed under the Apache License Version 2.0, which
+// can be found in the LICENSE file in the root directory of this source tree.
+
+package com.xiaomi.infra.pegasus.client;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestPException {
+  @Test
+  public void testThreadInterrupted() throws Exception {
+    PException ex = PException.threadInterrupted("test");
+    Assert.assertEquals(
+        "com.xiaomi.infra.pegasus.rpc.ReplicationException: ERR_THREAD_INTERRUPTED: [table=test] Thread is interrupted!",
+        ex.getMessage());
+  }
+
+  @Test
+  public void testTimeout() throws Exception {
+    PException ex = PException.timeout("test", 1000);
+    Assert.assertEquals(
+        "com.xiaomi.infra.pegasus.rpc.ReplicationException: ERR_TIMEOUT: [table=test, timeout=1000ms] Timeout on Future await!",
+        ex.getMessage());
+  }
+}

--- a/src/test/java/com/xiaomi/infra/pegasus/client/TestPException.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/client/TestPException.java
@@ -4,23 +4,24 @@
 
 package com.xiaomi.infra.pegasus.client;
 
+import java.util.concurrent.TimeoutException;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class TestPException {
   @Test
   public void testThreadInterrupted() throws Exception {
-    PException ex = PException.threadInterrupted("test");
+    PException ex = PException.threadInterrupted("test", new InterruptedException("intxxx"));
     Assert.assertEquals(
-        "com.xiaomi.infra.pegasus.rpc.ReplicationException: ERR_THREAD_INTERRUPTED: [table=test] Thread is interrupted!",
+        "com.xiaomi.infra.pegasus.rpc.ReplicationException: ERR_THREAD_INTERRUPTED: [table=test] Thread was interrupted: intxxx",
         ex.getMessage());
   }
 
   @Test
   public void testTimeout() throws Exception {
-    PException ex = PException.timeout("test", 1000);
+    PException ex = PException.timeout("test", 1000, new TimeoutException("tmxxx"));
     Assert.assertEquals(
-        "com.xiaomi.infra.pegasus.rpc.ReplicationException: ERR_TIMEOUT: [table=test, timeout=1000ms] Timeout on Future await!",
+        "com.xiaomi.infra.pegasus.rpc.ReplicationException: ERR_TIMEOUT: [table=test, timeout=1000ms] Timeout on Future await: tmxxx",
         ex.getMessage());
   }
 }


### PR DESCRIPTION
In most synchronous APIs of PegasusTable, when `Future.await` throws `InterruptedException` and `TimeoutException`, they are wrapped under PException with simply coded ERR_TIMEOUT. This makes it hard to distinguish the real problem.

So here we add more details on each exception, InterruptedException is coded ERR_THREAD_INTERRUPTED, and information like "tableName" and "timeout ms" is complemented.