### PR TITLE
fix: fix block bug of InetAddressValidator.getInstance()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,9 +14,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>commons-validator</groupId>
-      <artifactId>commons-validator</artifactId>
-      <version>1.6</version>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>28.1-jre</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/HostNameResolver.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/HostNameResolver.java
@@ -15,6 +15,9 @@ import java.nio.ByteOrder;
  */
 public class HostNameResolver {
 
+  private static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(HostNameResolver.class);
+
   public rpc_address[] resolve(String hostPort) throws IllegalArgumentException {
     String[] pairs = hostPort.split(":");
     if (pairs.length != 2) {
@@ -26,10 +29,12 @@ public class HostNameResolver {
       InetAddress[] resolvedAddresses = InetAddress.getAllByName(pairs[0]);
       rpc_address[] results = new rpc_address[resolvedAddresses.length];
       int size = 0;
+      logger.info("get all ip from the host {}", pairs[0]);
       for (InetAddress addr : resolvedAddresses) {
         rpc_address rpcAddr = new rpc_address();
         int ip = ByteBuffer.wrap(addr.getAddress()).order(ByteOrder.BIG_ENDIAN).getInt();
         rpcAddr.address = ((long) ip << 32) + ((long) port << 16) + 1;
+        logger.info("ip:{}", rpcAddr);
         results[size++] = rpcAddr;
       }
       return results;

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/HostNameResolver.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/HostNameResolver.java
@@ -26,15 +26,15 @@ public class HostNameResolver {
 
     try {
       Integer port = Integer.valueOf(pairs[1]);
+      logger.info("start to resolve hostname {} into ip addresses", pairs[0]);
       InetAddress[] resolvedAddresses = InetAddress.getAllByName(pairs[0]);
       rpc_address[] results = new rpc_address[resolvedAddresses.length];
       int size = 0;
-      logger.info("get all ip from the host {}", pairs[0]);
       for (InetAddress addr : resolvedAddresses) {
         rpc_address rpcAddr = new rpc_address();
         int ip = ByteBuffer.wrap(addr.getAddress()).order(ByteOrder.BIG_ENDIAN).getInt();
         rpcAddr.address = ((long) ip << 32) + ((long) port << 16) + 1;
-        logger.info("ip:{}", rpcAddr);
+        logger.info("resolved ip address {} from host {}", rpcAddr, pairs[0]);
         results[size++] = rpcAddr;
       }
       return results;

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/MetaSession.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/MetaSession.java
@@ -279,7 +279,6 @@ public class MetaSession extends HostNameResolver {
       metaList.add(clusterManager.getReplicaSession(addr));
       logger.info("add {} as meta server", addr);
     }
-    logger.info("resolve host completed!");
   }
 
   // Only for test.

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/MetaSession.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/MetaSession.java
@@ -3,6 +3,7 @@
 // can be found in the LICENSE file in the root directory of this source tree.
 package com.xiaomi.infra.pegasus.rpc.async;
 
+import com.google.common.net.InetAddresses;
 import com.xiaomi.infra.pegasus.base.error_code.error_types;
 import com.xiaomi.infra.pegasus.base.rpc_address;
 import com.xiaomi.infra.pegasus.operator.client_operator;
@@ -14,7 +15,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.validator.routines.InetAddressValidator;
 
 public class MetaSession extends HostNameResolver {
   public MetaSession(
@@ -27,7 +27,7 @@ public class MetaSession extends HostNameResolver {
     clusterManager = manager;
     metaList = new ArrayList<ReplicaSession>();
 
-    if (addrList.length == 1 && !InetAddressValidator.getInstance().isValid(addrList[0])) {
+    if (addrList.length == 1 && !InetAddresses.isInetAddress(addrList[0])) {
       // if the given string is not a valid ip address,
       // then take it as a hostname for a try.
       resolveHost(addrList[0]);
@@ -279,6 +279,7 @@ public class MetaSession extends HostNameResolver {
       metaList.add(clusterManager.getReplicaSession(addr));
       logger.info("add {} as meta server", addr);
     }
+    logger.info("resolve host completed!");
   }
 
   // Only for test.


### PR DESCRIPTION
DNS域名功能为了检测域名地址格式的有效性，使用了Apache 的`commons-validator` 包的 `InetAddressValidator.getInstance().isValid` 方法，其中`InetAddressValidator.getInstance()`在某些机器上可能会引起阻塞。目前并未发现引起阻塞的原因，该PR更换成了Guava包，该bug并未出现。