### PR TITLE
fix: use operation_timeout as socket connect timeout

### DIFF
--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/Cluster.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/Cluster.java
@@ -8,9 +8,6 @@ import com.xiaomi.infra.pegasus.thrift.TException;
 import java.util.Properties;
 
 public abstract class Cluster {
-  public static final int SOCK_TIMEOUT = 1000;
-  public static final int QUERY_META_TIMEOUT = 1000;
-
   public static final String PEGASUS_META_SERVERS_KEY = "meta_servers";
 
   public static final String PEGASUS_OPERATION_TIMEOUT_KEY = "operation_timeout";

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/ClusterManager.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/ClusterManager.java
@@ -83,7 +83,7 @@ public class ClusterManager extends Cluster {
     synchronized (this) {
       ss = replicaSessions.get(address);
       if (ss != null) return ss;
-      ss = new ReplicaSession(address, replicaGroup, Cluster.SOCK_TIMEOUT);
+      ss = new ReplicaSession(address, replicaGroup, operationTimeout);
       replicaSessions.put(address, ss);
       return ss;
     }


### PR DESCRIPTION
use operation_timeout as socket connect timeout, instead of Cluster.SOCK_TIMEOUT.

This fixes the problem that the client may request a disconnected replica-server when the session was unable to establish in `SOCKET_TIMEOUT` (aka 1 second), and finally gets `ERR_SESSION_RESET` error, even though its `operationTimeout` is 10 seconds.

This is user-unfriendly and counterintuitive because the user actually allows 10 seconds to wait, but the request didn't utilize the sufficient time budget.