### PR TITLE
fix: handle potential NullPointerException on RequestEntry.timeoutTask

### DIFF
--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/ReplicaSession.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/ReplicaSession.java
@@ -370,12 +370,12 @@ public class ReplicaSession {
 
   final Queue<RequestEntry> pendingSend = new LinkedList<RequestEntry>();
 
-  public static final class VolatileFields {
+  static final class VolatileFields {
     public ConnState state = ConnState.DISCONNECTED;
     public Channel nettyChannel = null;
   }
 
-  public volatile VolatileFields fields = new VolatileFields();
+  volatile VolatileFields fields = new VolatileFields();
 
   private final rpc_address address;
   private Bootstrap boot;

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/ReplicaSession.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/ReplicaSession.java
@@ -225,7 +225,7 @@ public class ReplicaSession {
   }
 
   // Notify the RPC sender if failure occurred.
-  private void tryNotifyWithSequenceID(int seqID, error_types errno, boolean isTimeoutTask) {
+  void tryNotifyWithSequenceID(int seqID, error_types errno, boolean isTimeoutTask) {
     logger.debug(
         "{}: {} is notified with error {}, isTimeoutTask {}",
         name(),
@@ -236,7 +236,6 @@ public class ReplicaSession {
     if (entry != null) {
       if (!isTimeoutTask && entry.timeoutTask != null) {
         entry.timeoutTask.cancel(true);
-        entry.timeoutTask = null;
       }
       if (errno == error_types.ERR_TIMEOUT) {
         long firstTs = firstRecentTimedOutMs.get();
@@ -352,7 +351,7 @@ public class ReplicaSession {
 
   MessageResponseFilter filter = null;
 
-  private final ConcurrentHashMap<Integer, RequestEntry> pendingResponse =
+  final ConcurrentHashMap<Integer, RequestEntry> pendingResponse =
       new ConcurrentHashMap<Integer, RequestEntry>();
   private final AtomicInteger seqId = new AtomicInteger(0);
 

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/ReplicaSession.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/ReplicaSession.java
@@ -310,8 +310,7 @@ public class ReplicaSession {
             try {
               tryNotifyWithSequenceID(seqID, error_types.ERR_TIMEOUT, true);
             } catch (Exception e) {
-              logger.warn(
-                  "try notify with sequenceID {} exception!", seqID, e);
+              logger.warn("try notify with sequenceID {} exception!", seqID, e);
             }
           }
         },

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/ReplicaSession.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/ReplicaSession.java
@@ -311,7 +311,7 @@ public class ReplicaSession {
               tryNotifyWithSequenceID(seqID, error_types.ERR_TIMEOUT, true);
             } catch (Exception e) {
               logger.warn(
-                  "try notify with sequenceID {} exception! message: {}", seqID, e.getMessage());
+                  "try notify with sequenceID {} exception! message: {}", seqID, e);
             }
           }
         },

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/ReplicaSession.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/ReplicaSession.java
@@ -311,7 +311,7 @@ public class ReplicaSession {
               tryNotifyWithSequenceID(seqID, error_types.ERR_TIMEOUT, true);
             } catch (Exception e) {
               logger.warn(
-                  "try notify with sequenceID {} exception! message: {}", seqID, e);
+                  "try notify with sequenceID {} exception!", seqID, e);
             }
           }
         },

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/ThriftFrameDecoder.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/ThriftFrameDecoder.java
@@ -52,7 +52,6 @@ public class ThriftFrameDecoder extends ByteToMessageDecoder {
         if (e != null) {
           if (e.timeoutTask != null) {
             e.timeoutTask.cancel(true);
-            e.timeoutTask = null;
           }
           e.op.rpc_error.errno = ec.errno;
           if (e.op.rpc_error.errno == error_code.error_types.ERR_OK) {

--- a/src/test/java/com/xiaomi/infra/pegasus/rpc/async/ReplicaSessionTest.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/rpc/async/ReplicaSessionTest.java
@@ -235,15 +235,13 @@ public class ReplicaSessionTest {
     ReplicaSession.RequestEntry entry = new ReplicaSession.RequestEntry();
     entry.sequenceId = 100;
     entry.callback = () -> passed.set(true);
-
-    // simulate the timeoutTask has been null
-    entry.timeoutTask = null;
+    entry.timeoutTask = null; // simulate the timeoutTask has been null
     entry.op = new rrdb_put_operator(new gpid(1, 1), null, null, 0);
     rs.pendingResponse.put(100, entry);
     rs.tryNotifyWithSequenceID(100, error_code.error_types.ERR_TIMEOUT, false);
     Assert.assertTrue(passed.get());
 
-    // simulate the entry has been removed
+    // simulate the entry has been removed, ensure no NPE thrown
     rs.getAndRemoveEntry(entry.sequenceId);
     rs.tryNotifyWithSequenceID(entry.sequenceId, entry.op.rpc_error.errno, true);
 

--- a/src/test/java/com/xiaomi/infra/pegasus/rpc/async/ReplicaSessionTest.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/rpc/async/ReplicaSessionTest.java
@@ -216,7 +216,7 @@ public class ReplicaSessionTest {
   }
 
   @Test
-  public void testTryNotifyWithSequenceID() {
+  public void testTryNotifyWithSequenceID() throws Exception {
     rpc_address addr = new rpc_address();
     addr.fromString("127.0.0.1:34801");
     ReplicaSession rs = manager.getReplicaSession(addr);

--- a/src/test/java/com/xiaomi/infra/pegasus/rpc/async/ReplicaSessionTest.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/rpc/async/ReplicaSessionTest.java
@@ -245,8 +245,7 @@ public class ReplicaSessionTest {
     rs.getAndRemoveEntry(entry.sequenceId);
     rs.tryNotifyWithSequenceID(entry.sequenceId, entry.op.rpc_error.errno, true);
 
-    // ensure must be marked session state to disconnect when TryNotifyWithSequenceID happen any
-    // exception
+    // ensure mark session state to disconnect when TryNotifyWithSequenceID incur any exception
     ReplicaSession mockRs = Mockito.spy(rs);
     mockRs.pendingSend.offer(entry);
     mockRs.fields.state = ConnState.CONNECTED;


### PR DESCRIPTION
```
[WARN  2019-12-04 21:00:08.478] [nioEventLoopGroup-3-1] com.xiaomi.infra.pegasus.rpc.async.ReplicaSession$DefaultHandler.exceptionCaught(ReplicaSession.java:332) [got exception in inbound handler [id: 0x37bcb165, L:/10.132.63.11:42530 ! R:/10.142.98.29:34801] for session rpc_address(10.142.98.29:34801): ]
java.lang.NullPointerException
        at com.xiaomi.infra.pegasus.rpc.async.ReplicaSession.tryNotifyWithSequenceID(ReplicaSession.java:237)
        at com.xiaomi.infra.pegasus.rpc.async.ReplicaSession.markSessionDisconnect(ReplicaSession.java:214)
        at com.xiaomi.infra.pegasus.rpc.async.ReplicaSession.access$200(ReplicaSession.java:25)
        at com.xiaomi.infra.pegasus.rpc.async.ReplicaSession$DefaultHandler.channelInactive(ReplicaSession.java:310)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:242)

```
[ReplicaSession.java:237](https://github.com/XiaoMi/pegasus-java-client/blob/thrift-0.11.0-inlined/src/main/java/com/xiaomi/infra/pegasus/rpc/async/ReplicaSession.java#L237)代码可能会引起空指针异常，导致[markSessionDisconnect](https://github.com/XiaoMi/pegasus-java-client/blob/thrift-0.11.0-inlined/src/main/java/com/xiaomi/infra/pegasus/rpc/async/ReplicaSession.java#L207)在某个channel被关闭的时候，无法正常标记该channel为disconnect状态，后续请求将一直使用该channel发送数据，导致失败。此次PR添加了空指针判断，使得markSessionDisconnect能够完整执行
