### PR TITLE
fix: make SetItem Serializable

### DIFF
--- a/src/main/java/com/xiaomi/infra/pegasus/client/SetItem.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/SetItem.java
@@ -3,7 +3,9 @@
 // can be found in the LICENSE file in the root directory of this source tree.
 package com.xiaomi.infra.pegasus.client;
 
-public class SetItem extends Serializable {
+import java.io.Serializable;
+
+public class SetItem implements Serializable {
   public byte[] hashKey = null;
   public byte[] sortKey = null;
   public byte[] value = null;

--- a/src/main/java/com/xiaomi/infra/pegasus/client/SetItem.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/SetItem.java
@@ -3,11 +3,7 @@
 // can be found in the LICENSE file in the root directory of this source tree.
 package com.xiaomi.infra.pegasus.client;
 
-/**
- * @author qinzuoyan
- *     <p>Set item.
- */
-public class SetItem {
+public class SetItem extends Serializable {
   public byte[] hashKey = null;
   public byte[] sortKey = null;
   public byte[] value = null;


### PR DESCRIPTION
Writing to Pegasus on Spark usually need to use batchSet API as well as `SetItem` for batching the writes.

![image](https://user-images.githubusercontent.com/6970676/80584164-dccbb100-8a43-11ea-9ffa-59ab67a8b55e.png)

But if we store `SetItem` in an RDD, there's a problem that `RDD[SetItem]` can not be serialized by Spark. Some exceptions will be thrown at runtime due to this cause. So here we make SetItem Serializable.