### PR TITLE
fix: startSortKey can't  pass null

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,19 +146,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.19.1</version>
-        <!--Execute JUnit 4 Tests with JUnit 5-->
-        <dependencies>
-          <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-surefire-provider</artifactId>
-            <version>1.0.0-M4</version>
-          </dependency>
-          <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>4.12.0-M4</version>
-          </dependency>
-        </dependencies>
         <configuration>
           <skipTests>${skipTests}</skipTests>
           <additionalClasspathElements>

--- a/pom.xml
+++ b/pom.xml
@@ -8,9 +8,15 @@
   <name>Pegasus Java Client</name>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.8.1</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.3.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-runner</artifactId>
+      <version>1.3.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -140,6 +146,19 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.19.1</version>
+        <!--Execute JUnit 4 Tests with JUnit 5-->
+        <dependencies>
+          <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-surefire-provider</artifactId>
+            <version>1.0.0-M4</version>
+          </dependency>
+          <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>4.12.0-M4</version>
+          </dependency>
+        </dependencies>
         <configuration>
           <skipTests>${skipTests}</skipTests>
           <additionalClasspathElements>

--- a/src/main/java/com/xiaomi/infra/pegasus/client/DelRangeOptions.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/DelRangeOptions.java
@@ -4,7 +4,7 @@
 package com.xiaomi.infra.pegasus.client;
 
 public class DelRangeOptions {
-  public String nextSortKey = "";
+  public byte[] nextSortKey = null;
   public boolean startInclusive = true; // if the startSortKey is included
   public boolean stopInclusive = false; // if the stopSortKey is included
   public FilterType sortKeyFilterType = FilterType.FT_NO_FILTER; // filter type for sort key

--- a/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
@@ -1455,6 +1455,9 @@ public class PegasusTable implements PegasusTableInterface {
   public void delRange(
       byte[] hashKey, byte[] startSortKey, byte[] stopSortKey, DelRangeOptions options, int timeout)
       throws PException {
+    if (hashKey == null || hashKey.length == 0) {
+      throw new PException("Invalid parameter: hash key can't be empty");
+    }
     if (timeout <= 0) timeout = defaultTimeout;
     long startTime = System.currentTimeMillis();
     long lastCheckTime = startTime;
@@ -1474,13 +1477,15 @@ public class PegasusTable implements PegasusTableInterface {
         getScanner(hashKey, startSortKey, stopSortKey, scanOptions);
     lastCheckTime = System.currentTimeMillis();
     if (lastCheckTime >= deadlineTime) {
+      String startSortKeyStr = startSortKey == null ? "" : new String(startSortKey);
+      String stopSortKeyStr = stopSortKey == null ? "" : new String(stopSortKey);
       throw new PException(
           "Getting pegasusScanner takes too long time when delete hashKey:"
               + new String(hashKey)
               + ",startSortKey:"
-              + new String(startSortKey)
+              + startSortKeyStr
               + ",stopSortKey:"
-              + new String(stopSortKey)
+              + stopSortKeyStr
               + ",timeUsed:"
               + (lastCheckTime - startTime)
               + ":",
@@ -1510,11 +1515,12 @@ public class PegasusTable implements PegasusTableInterface {
         options.nextSortKey = null;
       }
     } catch (InterruptedException | ExecutionException e) {
+      String nextSortKeyStr = options.nextSortKey == null ? "" : new String(options.nextSortKey);
       throw new PException(
           "delRange of hashKey:"
               + new String(hashKey)
               + " from sortKey:"
-              + new String(options.nextSortKey)
+              + nextSortKeyStr
               + "[index:"
               + count * maxBatchDelCount
               + "]"

--- a/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/PegasusTable.java
@@ -1469,7 +1469,7 @@ public class PegasusTable implements PegasusTableInterface {
     scanOptions.sortKeyFilterType = options.sortKeyFilterType;
     scanOptions.sortKeyFilterPattern = options.sortKeyFilterPattern;
 
-    options.nextSortKey = new String(startSortKey);
+    options.nextSortKey = startSortKey;
     PegasusScannerInterface pegasusScanner =
         getScanner(hashKey, startSortKey, stopSortKey, scanOptions);
     lastCheckTime = System.currentTimeMillis();
@@ -1494,7 +1494,7 @@ public class PegasusTable implements PegasusTableInterface {
       while ((pairs = pegasusScanner.next()) != null) {
         sortKeys.add(pairs.getKey().getValue());
         if (sortKeys.size() == maxBatchDelCount) {
-          options.nextSortKey = new String(sortKeys.get(0));
+          options.nextSortKey = sortKeys.get(0);
           asyncMultiDel(hashKey, sortKeys, remainingTime).get(remainingTime, TimeUnit.MILLISECONDS);
           lastCheckTime = System.currentTimeMillis();
           remainingTime = (int) (deadlineTime - lastCheckTime);
@@ -1514,7 +1514,7 @@ public class PegasusTable implements PegasusTableInterface {
           "delRange of hashKey:"
               + new String(hashKey)
               + " from sortKey:"
-              + options.nextSortKey
+              + new String(options.nextSortKey)
               + "[index:"
               + count * maxBatchDelCount
               + "]"

--- a/src/test/java/com/xiaomi/infra/pegasus/client/TestBasic.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/client/TestBasic.java
@@ -12,7 +12,9 @@ import java.util.Map;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 /** Created by mi on 16-3-22. */
 public class TestBasic {
@@ -2369,156 +2371,142 @@ public class TestBasic {
     // multi set values
     List<Pair<byte[], byte[]>> values = new ArrayList<Pair<byte[], byte[]>>();
     int count = 0;
-    try {
-      while (count < 150) {
-        values.add(Pair.of(("k_" + count).getBytes(), ("v_" + count).getBytes()));
-        count++;
-      }
-      client.multiSet(tableName, "delRange".getBytes(), values);
-    } catch (Exception e) {
-      e.printStackTrace();
-      Assert.assertTrue(false);
-    }
 
-    // delRange with default delRangeOptions
-    try {
-      client.delRange(
-          tableName, "delRange".getBytes(), "k_0".getBytes(), "k_90".getBytes(), delRangeOptions);
-    } catch (Exception e) {
-      e.printStackTrace();
-      Assert.assertTrue(false);
+    while (count < 150) {
+      values.add(Pair.of(("k_" + count).getBytes(), ("v_" + count).getBytes()));
+      count++;
     }
-
-    Assert.assertTrue(delRangeOptions.nextSortKey == null);
     List<byte[]> remainingSortKey = new ArrayList<byte[]>();
-
-    remainingSortKey.add("k_90".getBytes());
-    remainingSortKey.add("k_91".getBytes());
-    remainingSortKey.add("k_92".getBytes());
-    remainingSortKey.add("k_93".getBytes());
-    remainingSortKey.add("k_94".getBytes());
-    remainingSortKey.add("k_95".getBytes());
-    remainingSortKey.add("k_96".getBytes());
-    remainingSortKey.add("k_97".getBytes());
-    remainingSortKey.add("k_98".getBytes());
-    remainingSortKey.add("k_99".getBytes());
     List<Pair<byte[], byte[]>> remainingValue = new ArrayList<Pair<byte[], byte[]>>();
 
-    try {
-      client.multiGet(tableName, "delRange".getBytes(), remainingSortKey, remainingValue);
-    } catch (Exception e) {
-      e.printStackTrace();
-      Assert.assertTrue(false);
-    }
+    Assertions.assertNull(
+        Assertions.assertDoesNotThrow(
+            () -> {
+              client.multiSet(tableName, "delRange".getBytes(), values);
+              client.delRange(
+                  tableName,
+                  "delRange".getBytes(),
+                  "k_0".getBytes(),
+                  "k_90".getBytes(),
+                  delRangeOptions);
+
+              remainingSortKey.add("k_90".getBytes());
+              remainingSortKey.add("k_91".getBytes());
+              remainingSortKey.add("k_92".getBytes());
+              remainingSortKey.add("k_93".getBytes());
+              remainingSortKey.add("k_94".getBytes());
+              remainingSortKey.add("k_95".getBytes());
+              remainingSortKey.add("k_96".getBytes());
+              remainingSortKey.add("k_97".getBytes());
+              remainingSortKey.add("k_98".getBytes());
+              remainingSortKey.add("k_99".getBytes());
+              client.multiGet(tableName, "delRange".getBytes(), remainingSortKey, remainingValue);
+
+              return delRangeOptions.nextSortKey;
+            }));
 
     List<String> valueStr = new ArrayList<String>();
     for (Pair<byte[], byte[]> pair : remainingValue) {
       valueStr.add(new String(pair.getValue()));
     }
-    Assert.assertEquals(10, valueStr.size());
-    Assert.assertTrue(valueStr.contains("v_90"));
-    Assert.assertTrue(valueStr.contains("v_91"));
-    Assert.assertTrue(valueStr.contains("v_92"));
-    Assert.assertTrue(valueStr.contains("v_93"));
-    Assert.assertTrue(valueStr.contains("v_94"));
-    Assert.assertTrue(valueStr.contains("v_95"));
-    Assert.assertTrue(valueStr.contains("v_96"));
-    Assert.assertTrue(valueStr.contains("v_97"));
-    Assert.assertTrue(valueStr.contains("v_98"));
-    Assert.assertTrue(valueStr.contains("v_99"));
+    Assertions.assertEquals(10, valueStr.size());
+    Assertions.assertTrue(valueStr.contains("v_90"));
+    Assertions.assertTrue(valueStr.contains("v_91"));
+    Assertions.assertTrue(valueStr.contains("v_92"));
+    Assertions.assertTrue(valueStr.contains("v_93"));
+    Assertions.assertTrue(valueStr.contains("v_94"));
+    Assertions.assertTrue(valueStr.contains("v_95"));
+    Assertions.assertTrue(valueStr.contains("v_96"));
+    Assertions.assertTrue(valueStr.contains("v_97"));
+    Assertions.assertTrue(valueStr.contains("v_98"));
+    Assertions.assertTrue(valueStr.contains("v_99"));
+    remainingValue.clear();
+    valueStr.clear();
 
     // delRange with FT_MATCH_POSTFIX option
     delRangeOptions.sortKeyFilterType = FilterType.FT_MATCH_POSTFIX;
     delRangeOptions.sortKeyFilterPattern = "k_93".getBytes();
-    try {
-      client.delRange(
-          tableName, "delRange".getBytes(), "k_90".getBytes(), "k_95".getBytes(), delRangeOptions);
-    } catch (Exception e) {
-      e.printStackTrace();
-      Assert.assertTrue(false);
-    }
 
-    remainingValue.clear();
-    valueStr.clear();
-    try {
-      client.multiGet(tableName, "delRange".getBytes(), remainingSortKey, remainingValue);
-    } catch (Exception e) {
-      e.printStackTrace();
-      Assert.assertTrue(false);
-    }
+    Assertions.assertDoesNotThrow(
+        () -> {
+          client.delRange(
+              tableName,
+              "delRange".getBytes(),
+              "k_90".getBytes(),
+              "k_95".getBytes(),
+              delRangeOptions);
+          client.multiGet(tableName, "delRange".getBytes(), remainingSortKey, remainingValue);
+        });
     for (Pair<byte[], byte[]> pair : remainingValue) {
       valueStr.add(new String(pair.getValue()));
     }
-
-    Assert.assertEquals(9, valueStr.size());
-    Assert.assertTrue(!valueStr.contains("v_93"));
+    Assertions.assertEquals(9, valueStr.size());
+    Assertions.assertTrue(!valueStr.contains("v_93"));
+    remainingValue.clear();
+    valueStr.clear();
 
     // delRange with "*Inclusive" option
     delRangeOptions.startInclusive = false;
     delRangeOptions.stopInclusive = true;
     delRangeOptions.sortKeyFilterType = FilterType.FT_NO_FILTER;
     delRangeOptions.sortKeyFilterPattern = null;
-    try {
-      client.delRange(
-          tableName, "delRange".getBytes(), "k_90".getBytes(), "k_95".getBytes(), delRangeOptions);
-    } catch (Exception e) {
-      e.printStackTrace();
-      Assert.assertTrue(false);
-    }
+    Assertions.assertDoesNotThrow(
+        () -> {
+          client.delRange(
+              tableName,
+              "delRange".getBytes(),
+              "k_90".getBytes(),
+              "k_95".getBytes(),
+              delRangeOptions);
+          client.multiGet(tableName, "delRange".getBytes(), remainingSortKey, remainingValue);
+        });
 
-    remainingValue.clear();
-    valueStr.clear();
-    try {
-      client.multiGet(tableName, "delRange".getBytes(), remainingSortKey, remainingValue);
-    } catch (Exception e) {
-      e.printStackTrace();
-      Assert.assertTrue(false);
-    }
     for (Pair<byte[], byte[]> pair : remainingValue) {
       valueStr.add(new String(pair.getValue()));
     }
 
-    Assert.assertEquals(5, valueStr.size());
-    Assert.assertTrue(valueStr.contains("v_90"));
-    Assert.assertTrue(valueStr.contains("v_96"));
-    Assert.assertTrue(valueStr.contains("v_97"));
-    Assert.assertTrue(valueStr.contains("v_98"));
-    Assert.assertTrue(valueStr.contains("v_99"));
-
+    Assertions.assertEquals(5, valueStr.size());
+    Assertions.assertTrue(valueStr.contains("v_90"));
+    Assertions.assertTrue(valueStr.contains("v_96"));
+    Assertions.assertTrue(valueStr.contains("v_97"));
+    Assertions.assertTrue(valueStr.contains("v_98"));
+    Assertions.assertTrue(valueStr.contains("v_99"));
     remainingValue.clear();
     valueStr.clear();
+
     DelRangeOptions delRangeOptions2 = new DelRangeOptions();
-
     // test hashKey can't be null or ""
-    try {
-      client.delRange(
-          tableName, "delRange".getBytes(), "k1".getBytes(), "k2".getBytes(), delRangeOptions2);
-    } catch (Exception e) {
-      Assert.assertTrue(e.getMessage().contains("Invalid parameter: hash key can't be empty"));
-    }
+    Assertions.assertEquals(
+        "{version}: Invalid parameter: hash key can't be empty",
+        Assertions.assertThrows(
+                PException.class,
+                () -> {
+                  client.delRange(
+                      tableName, null, "k1".getBytes(), "k2".getBytes(), delRangeOptions2);
+                })
+            .getMessage());
 
-    try {
-      client.delRange(tableName, "".getBytes(), "k1".getBytes(), "k2".getBytes(), delRangeOptions2);
-    } catch (Exception e) {
-      Assert.assertTrue(e.getMessage().contains("Invalid parameter: hash key can't be empty"));
-    }
+    Assertions.assertEquals(
+        "{version}: Invalid parameter: hash key can't be empty",
+        Assertions.assertThrows(
+                PException.class,
+                () -> {
+                  client.delRange(
+                      tableName, "".getBytes(), "k1".getBytes(), "k2".getBytes(), delRangeOptions2);
+                })
+            .getMessage());
 
     // test sortKey can be null, means delete from first to last
-    try {
-      client.multiSet(tableName, "delRange".getBytes(), values);
-      client.delRange(tableName, "delRange".getBytes(), null, null, delRangeOptions2);
-      client.multiGet(tableName, "delRange".getBytes(), remainingSortKey, remainingValue);
-    } catch (Exception e) {
-      e.printStackTrace();
-      Assert.assertTrue(false);
-    }
+    Assertions.assertNull(
+        Assertions.assertDoesNotThrow(
+            () -> {
+              client.multiSet(tableName, "delRange".getBytes(), values);
+              client.delRange(tableName, "delRange".getBytes(), null, null, delRangeOptions2);
+              client.multiGet(tableName, "delRange".getBytes(), remainingSortKey, remainingValue);
+              return delRangeOptions2.nextSortKey;
+            }));
 
-    for (Pair<byte[], byte[]> pair : remainingValue) {
-      valueStr.add(new String(pair.getValue()));
-    }
-
-    Assert.assertNull(delRangeOptions.nextSortKey);
-    Assert.assertEquals(valueStr.size(), 0);
+    Assertions.assertEquals(remainingValue.size(), 0);
   }
 
   @Test

--- a/src/test/java/com/xiaomi/infra/pegasus/client/TestBasic.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/client/TestBasic.java
@@ -2490,7 +2490,6 @@ public class TestBasic {
     DelRangeOptions delRangeOptions2 = new DelRangeOptions();
 
     // test hashKey can't be null or ""
-
     try {
       client.delRange(
           tableName, "delRange".getBytes(), "k1".getBytes(), "k2".getBytes(), delRangeOptions2);

--- a/src/test/java/com/xiaomi/infra/pegasus/client/TestBasic.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/client/TestBasic.java
@@ -2364,6 +2364,8 @@ public class TestBasic {
     PegasusClientInterface client = PegasusClientFactory.getSingletonClient();
     DelRangeOptions delRangeOptions = new DelRangeOptions();
 
+    String tableName = "temp";
+
     // multi set values
     List<Pair<byte[], byte[]>> values = new ArrayList<Pair<byte[], byte[]>>();
     int count = 0;
@@ -2372,7 +2374,7 @@ public class TestBasic {
         values.add(Pair.of(("k_" + count).getBytes(), ("v_" + count).getBytes()));
         count++;
       }
-      client.multiSet("temp", "delRange".getBytes(), values);
+      client.multiSet(tableName, "delRange".getBytes(), values);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.assertTrue(false);
@@ -2381,7 +2383,7 @@ public class TestBasic {
     // delRange with default delRangeOptions
     try {
       client.delRange(
-          "temp", "delRange".getBytes(), "k_0".getBytes(), "k_90".getBytes(), delRangeOptions);
+          tableName, "delRange".getBytes(), "k_0".getBytes(), "k_90".getBytes(), delRangeOptions);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.assertTrue(false);
@@ -2403,7 +2405,7 @@ public class TestBasic {
     List<Pair<byte[], byte[]>> remainingValue = new ArrayList<Pair<byte[], byte[]>>();
 
     try {
-      client.multiGet("temp", "delRange".getBytes(), remainingSortKey, remainingValue);
+      client.multiGet(tableName, "delRange".getBytes(), remainingSortKey, remainingValue);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.assertTrue(false);
@@ -2430,7 +2432,7 @@ public class TestBasic {
     delRangeOptions.sortKeyFilterPattern = "k_93".getBytes();
     try {
       client.delRange(
-          "temp", "delRange".getBytes(), "k_90".getBytes(), "k_95".getBytes(), delRangeOptions);
+          tableName, "delRange".getBytes(), "k_90".getBytes(), "k_95".getBytes(), delRangeOptions);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.assertTrue(false);
@@ -2439,7 +2441,7 @@ public class TestBasic {
     remainingValue.clear();
     valueStr.clear();
     try {
-      client.multiGet("temp", "delRange".getBytes(), remainingSortKey, remainingValue);
+      client.multiGet(tableName, "delRange".getBytes(), remainingSortKey, remainingValue);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.assertTrue(false);
@@ -2458,7 +2460,7 @@ public class TestBasic {
     delRangeOptions.sortKeyFilterPattern = null;
     try {
       client.delRange(
-          "temp", "delRange".getBytes(), "k_90".getBytes(), "k_95".getBytes(), delRangeOptions);
+          tableName, "delRange".getBytes(), "k_90".getBytes(), "k_95".getBytes(), delRangeOptions);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.assertTrue(false);
@@ -2467,7 +2469,7 @@ public class TestBasic {
     remainingValue.clear();
     valueStr.clear();
     try {
-      client.multiGet("temp", "delRange".getBytes(), remainingSortKey, remainingValue);
+      client.multiGet(tableName, "delRange".getBytes(), remainingSortKey, remainingValue);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.assertTrue(false);
@@ -2482,6 +2484,42 @@ public class TestBasic {
     Assert.assertTrue(valueStr.contains("v_97"));
     Assert.assertTrue(valueStr.contains("v_98"));
     Assert.assertTrue(valueStr.contains("v_99"));
+
+    remainingValue.clear();
+    valueStr.clear();
+    DelRangeOptions delRangeOptions2 = new DelRangeOptions();
+
+    // test hashKey can't be null or ""
+
+    try {
+      client.delRange(
+          tableName, "delRange".getBytes(), "k1".getBytes(), "k2".getBytes(), delRangeOptions2);
+    } catch (Exception e) {
+      Assert.assertTrue(e.getMessage().contains("Invalid parameter: hash key can't be empty"));
+    }
+
+    try {
+      client.delRange(tableName, "".getBytes(), "k1".getBytes(), "k2".getBytes(), delRangeOptions2);
+    } catch (Exception e) {
+      Assert.assertTrue(e.getMessage().contains("Invalid parameter: hash key can't be empty"));
+    }
+
+    // test sortKey can be null, means delete from first to last
+    try {
+      client.multiSet(tableName, "delRange".getBytes(), values);
+      client.delRange(tableName, "delRange".getBytes(), null, null, delRangeOptions2);
+      client.multiGet(tableName, "delRange".getBytes(), remainingSortKey, remainingValue);
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assert.assertTrue(false);
+    }
+
+    for (Pair<byte[], byte[]> pair : remainingValue) {
+      valueStr.add(new String(pair.getValue()));
+    }
+
+    Assert.assertNull(delRangeOptions.nextSortKey);
+    Assert.assertEquals(valueStr.size(), 0);
   }
 
   @Test


### PR DESCRIPTION
`startSortKey` should support pass `null` 


```java
  public void delRange(
      byte[] hashKey, byte[] startSortKey, byte[] stopSortKey, DelRangeOptions options, int timeout)
      throws PException {
    ScanOptions scanOptions = new ScanOptions();
    scanOptions.noValue = true;
    scanOptions.startInclusive = options.startInclusive;
    scanOptions.stopInclusive = options.stopInclusive;
    scanOptions.sortKeyFilterType = options.sortKeyFilterType;
    scanOptions.sortKeyFilterPattern = options.sortKeyFilterPattern;

    options.nextSortKey = new String(startSortKey);
```

```java
public class DelRangeOptions {
  public String nextSortKey = "";
```

Because DelRangeOptions.nextSortKey was a string, if startSortKey was passed null, `new String(null)` will throw NullPointerException.

**Besides**, this pr update junit4 to junit5 for simplying unit code, for example, support test `exception` method, see [junit5](https://howtodoinjava.com/junit5/expected-exception-example/)