### PR TITLE
fix: revert default asyncWorkers value

### DIFF
--- a/src/main/java/com/xiaomi/infra/pegasus/client/ClientOptions.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/client/ClientOptions.java
@@ -34,7 +34,7 @@ public class ClientOptions {
   public static final String DEFAULT_META_SERVERS =
       "127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603";
   public static final Duration DEFAULT_OPERATION_TIMEOUT = Duration.ofMillis(1000);
-  public static final int DEFAULT_ASYNC_WORKERS = Runtime.getRuntime().availableProcessors();
+  public static final int DEFAULT_ASYNC_WORKERS = 4;
   public static final boolean DEFAULT_ENABLE_PERF_COUNTER = true;
   public static final String DEFAULT_FALCON_PERF_COUNTER_TAGS = "";
   public static final Duration DEFAULT_FALCON_PUSH_INTERVAL = Duration.ofSeconds(10);

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/ClusterOptions.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/ClusterOptions.java
@@ -15,8 +15,7 @@ public class ClusterOptions {
   public static final String PEGASUS_OPERATION_TIMEOUT_DEF = "1000";
 
   public static final String PEGASUS_ASYNC_WORKERS_KEY = "async_workers";
-  public static final String PEGASUS_ASYNC_WORKERS_DEF =
-      String.valueOf(Runtime.getRuntime().availableProcessors());
+  public static final String PEGASUS_ASYNC_WORKERS_DEF = "4";
 
   public static final String PEGASUS_ENABLE_PERF_COUNTER_KEY = "enable_perf_counter";
   public static final String PEGASUS_ENABLE_PERF_COUNTER_DEF = "true";


### PR DESCRIPTION
#76 set the `asyncWorkers = Runtime.getRuntime().availableProcessors()`, however it is useless, this pr revert it to `4`