### PR TITLE
refactor: restrict enableBackupRequest to read_operator

### DIFF
--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -28,8 +28,8 @@ fi
 
 # The new version of pegasus client is not compatible with old version server which contains old rpc protocol,
 # So we use snapshot version of pegasus-tools, because we don`t have a new release version, which contains the new version of rpc protocol,
-PEGASUS_PKG="pegasus-tools-1.13.SNAPSHOT-695b366-glibc2.17-release"
-PEGASUS_PKG_URL="https://github.com/XiaoMi/pegasus-common/releases/download/deps/pegasus-tools-1.13.SNAPSHOT-695b366-glibc2.17-release.tar.gz"
+PEGASUS_PKG="pegasus-tools-2.0.0-5d969e8-glibc2.12-release"
+PEGASUS_PKG_URL="https://github.com/apache/incubator-pegasus/releases/download/v2.0.0/pegasus-tools-2.0.0-5d969e8-glibc2.12-release.tar.gz"
 
 # start pegasus onebox environment
 if [ ! -f $PEGASUS_PKG.tar.gz ]; then
@@ -38,7 +38,6 @@ if [ ! -f $PEGASUS_PKG.tar.gz ]; then
 fi
 cd $PEGASUS_PKG
 
-sed -i "s#https://github.com/xiaomi/pegasus-common/raw/master/zookeeper-3.4.6.tar.gz#https://github.com/XiaoMi/pegasus-common/releases/download/deps/zookeeper-3.4.6.tar.gz#" scripts/start_zk.sh
 ./run.sh start_onebox -w
 cd ../
 

--- a/src/main/java/com/xiaomi/infra/pegasus/operator/client_operator.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/operator/client_operator.java
@@ -12,8 +12,15 @@ import org.apache.thrift.protocol.TProtocol;
 
 public abstract class client_operator {
 
-  public client_operator(
-      gpid gpid, String tableName, long partitionHash, boolean enableBackupRequest) {
+  /**
+   * Whether does this RPC support backup request.<br>
+   * Generally, only read-operations supports backup request which sacrifices strong-consistency.
+   */
+  public boolean supportBackupRequest() {
+    return true;
+  }
+
+  public client_operator(gpid gpid, String tableName, long partitionHash) {
     this.header = new ThriftHeader();
     this.meta = new request_meta();
     this.meta.setApp_id(gpid.get_app_id());
@@ -22,11 +29,6 @@ public abstract class client_operator {
     this.pid = gpid;
     this.tableName = tableName;
     this.rpc_error = new error_code();
-    this.enableBackupRequest = enableBackupRequest;
-  }
-
-  public client_operator(gpid gpid, String tableName, long partitionHash) {
-    this(gpid, tableName, partitionHash, false);
   }
 
   public final byte[] prepare_thrift_header(int meta_length, int body_length) {
@@ -93,5 +95,4 @@ public abstract class client_operator {
   public gpid pid;
   public String tableName; // only for metrics
   public error_code rpc_error;
-  public boolean enableBackupRequest;
 }

--- a/src/main/java/com/xiaomi/infra/pegasus/operator/client_operator.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/operator/client_operator.java
@@ -17,7 +17,7 @@ public abstract class client_operator {
    * Generally, only read-operations supports backup request which sacrifices strong-consistency.
    */
   public boolean supportBackupRequest() {
-    return true;
+    return false;
   }
 
   public client_operator(gpid gpid, String tableName, long partitionHash) {

--- a/src/main/java/com/xiaomi/infra/pegasus/operator/client_operator.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/operator/client_operator.java
@@ -14,7 +14,7 @@ public abstract class client_operator {
 
   /**
    * Whether does this RPC support backup request.<br>
-   * Generally, only read-operations supports backup request which sacrifices strong-consistency.
+   * Generally, only read-operations support backup-request which sacrifices strong-consistency.
    */
   public boolean supportBackupRequest() {
     return false;

--- a/src/main/java/com/xiaomi/infra/pegasus/operator/read_operator.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/operator/read_operator.java
@@ -1,0 +1,32 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.xiaomi.infra.pegasus.operator;
+
+import com.xiaomi.infra.pegasus.base.gpid;
+
+/** Identifies that an RPC is a pure read-operation. */
+abstract class ReadOperator extends client_operator {
+  public ReadOperator(gpid gpid, String tableName, long partitionHash) {
+    super(gpid, tableName, partitionHash);
+  }
+
+  @Override
+  public boolean supportBackupRequest() {
+    return true;
+  }
+}

--- a/src/main/java/com/xiaomi/infra/pegasus/operator/read_operator.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/operator/read_operator.java
@@ -20,8 +20,8 @@ package com.xiaomi.infra.pegasus.operator;
 import com.xiaomi.infra.pegasus.base.gpid;
 
 /** Identifies that an RPC is a pure read-operation. */
-abstract class ReadOperator extends client_operator {
-  public ReadOperator(gpid gpid, String tableName, long partitionHash) {
+abstract class read_operator extends client_operator {
+  public read_operator(gpid gpid, String tableName, long partitionHash) {
     super(gpid, tableName, partitionHash);
   }
 

--- a/src/main/java/com/xiaomi/infra/pegasus/operator/rrdb_get_operator.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/operator/rrdb_get_operator.java
@@ -11,10 +11,10 @@ import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TMessage;
 import org.apache.thrift.protocol.TMessageType;
 
-public class rrdb_get_operator extends client_operator {
+public class rrdb_get_operator extends read_operator {
   public rrdb_get_operator(
       com.xiaomi.infra.pegasus.base.gpid gpid, String tableName, blob request, long partitionHash) {
-    super(gpid, tableName, partitionHash, true);
+    super(gpid, tableName, partitionHash);
     this.request = request;
   }
 

--- a/src/main/java/com/xiaomi/infra/pegasus/operator/rrdb_multi_get_operator.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/operator/rrdb_multi_get_operator.java
@@ -16,7 +16,7 @@ public class rrdb_multi_get_operator extends client_operator {
       String tableName,
       multi_get_request request,
       long partitionHash) {
-    super(gpid, tableName, partitionHash, true);
+    super(gpid, tableName, partitionHash);
     this.request = request;
   }
 

--- a/src/main/java/com/xiaomi/infra/pegasus/operator/rrdb_multi_get_operator.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/operator/rrdb_multi_get_operator.java
@@ -10,7 +10,7 @@ import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TMessage;
 import org.apache.thrift.protocol.TMessageType;
 
-public class rrdb_multi_get_operator extends client_operator {
+public class rrdb_multi_get_operator extends read_operator {
   public rrdb_multi_get_operator(
       com.xiaomi.infra.pegasus.base.gpid gpid,
       String tableName,

--- a/src/main/java/com/xiaomi/infra/pegasus/operator/rrdb_ttl_operator.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/operator/rrdb_ttl_operator.java
@@ -10,10 +10,10 @@ import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TMessage;
 import org.apache.thrift.protocol.TMessageType;
 
-public class rrdb_ttl_operator extends client_operator {
+public class rrdb_ttl_operator extends read_operator {
   public rrdb_ttl_operator(
       com.xiaomi.infra.pegasus.base.gpid gpid, String tableName, blob request, long partitionHash) {
-    super(gpid, tableName, partitionHash, true);
+    super(gpid, tableName, partitionHash);
     this.request = request;
   }
 

--- a/src/main/java/com/xiaomi/infra/pegasus/rpc/async/TableHandler.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/rpc/async/TableHandler.java
@@ -365,7 +365,7 @@ public class TableHandler extends Table {
 
     if (handle.primarySession != null) {
       // if backup request is enabled, schedule to send to secondary
-      if (round.operator.enableBackupRequest && isBackupRequestEnabled()) {
+      if (round.operator.supportBackupRequest() && isBackupRequestEnabled()) {
         backupCall(round, tryId);
       }
 

--- a/src/test/java/com/xiaomi/infra/pegasus/operator/ClientOperatorTest.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/operator/ClientOperatorTest.java
@@ -1,0 +1,33 @@
+package com.xiaomi.infra.pegasus.operator;
+
+import com.xiaomi.infra.pegasus.apps.check_and_mutate_request;
+import com.xiaomi.infra.pegasus.apps.multi_get_request;
+import com.xiaomi.infra.pegasus.apps.update_request;
+import com.xiaomi.infra.pegasus.base.blob;
+import com.xiaomi.infra.pegasus.base.gpid;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ClientOperatorTest {
+
+  @Test
+  public void testSupportBackupRequest() {
+    client_operator op =
+        new rrdb_multi_get_operator(new gpid(1, 1), "test", new multi_get_request(), 0);
+    Assert.assertTrue(op.supportBackupRequest());
+
+    op = new rrdb_get_operator(new gpid(1, 1), "test", new blob(), 0);
+    Assert.assertTrue(op.supportBackupRequest());
+
+    op = new rrdb_ttl_operator(new gpid(1, 1), "test", new blob(), 0);
+    Assert.assertTrue(op.supportBackupRequest());
+
+    op = new rrdb_put_operator(new gpid(1, 1), "test", new update_request(), 0);
+    Assert.assertFalse(op.supportBackupRequest());
+
+    op =
+        new rrdb_check_and_mutate_operator(
+            new gpid(1, 1), "test", new check_and_mutate_request(), 0);
+    Assert.assertFalse(op.supportBackupRequest());
+  }
+}


### PR DESCRIPTION
`client_operator#enableBackupRequest` was ambigious with user configuration `TableHandler#isBackupRequestEnabled`.

`client_operator#enableBackupRequest` is actually not given by users. The word "enable" is not accurate. I'd like to use "support" instead. Because only reads support backup-request.