### PR TITLE
feat(security): refresh tgt in background

### DIFF
--- a/idl/apache-licence-template
+++ b/idl/apache-licence-template
@@ -1,3 +1,16 @@
-// Copyright (c) 2017, Xiaomi, Inc.  All rights reserved.
-// This source code is licensed under the Apache License Version 2.0, which
-// can be found in the LICENSE file in the root directory of this source tree.
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.

--- a/src/main/java/com/xiaomi/infra/pegasus/security/KerberosProtocol.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/security/KerberosProtocol.java
@@ -52,7 +52,7 @@ class KerberosProtocol implements AuthProtocol {
   private String serviceFqdn;
   private String keyTab;
   private String principal;
-  final int CHECK_TGT_INTEVAL = 30 * 1000;
+  final int CHECK_TGT_INTEVAL_SECONDS = 10;
 
   KerberosProtocol(String serviceName, String serviceFqdn, String keyTab, String principal)
       throws IllegalArgumentException {
@@ -62,7 +62,7 @@ class KerberosProtocol implements AuthProtocol {
     this.principal = principal;
 
     this.login();
-    scheduleRefreshTGT();
+    scheduleCheckTGTAndRelogin();
     logger.info("login succeed, as user {}", subject.getPrincipals().toString());
   }
 
@@ -105,9 +105,9 @@ class KerberosProtocol implements AuthProtocol {
     };
   }
 
-  private void scheduleRefreshTGT() {
+  private void scheduleCheckTGTAndRelogin() {
     ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor();
-    service.scheduleAtFixedRate(() -> checkTGTAndRelogin(), CHECK_TGT_INTEVAL, CHECK_TGT_INTEVAL, TimeUnit.SECONDS);
+    service.scheduleAtFixedRate(() -> checkTGTAndRelogin(), CHECK_TGT_INTEVAL_SECONDS, CHECK_TGT_INTEVAL_SECONDS, TimeUnit.SECONDS);
   }
 
   private void checkTGTAndRelogin() {

--- a/src/main/java/com/xiaomi/infra/pegasus/security/KerberosProtocol.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/security/KerberosProtocol.java
@@ -107,7 +107,11 @@ class KerberosProtocol implements AuthProtocol {
 
   private void scheduleCheckTGTAndRelogin() {
     ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor();
-    service.scheduleAtFixedRate(() -> checkTGTAndRelogin(), CHECK_TGT_INTEVAL_SECONDS, CHECK_TGT_INTEVAL_SECONDS, TimeUnit.SECONDS);
+    service.scheduleAtFixedRate(
+        () -> checkTGTAndRelogin(),
+        CHECK_TGT_INTEVAL_SECONDS,
+        CHECK_TGT_INTEVAL_SECONDS,
+        TimeUnit.SECONDS);
   }
 
   private void checkTGTAndRelogin() {
@@ -125,7 +129,7 @@ class KerberosProtocol implements AuthProtocol {
   private long getRefreshTime(KerberosTicket tgt) {
     long start = tgt.getStartTime().getTime();
     long end = tgt.getEndTime().getTime();
-    return start + (long)((float)(end - start) * 0.8F);
+    return start + (long) ((float) (end - start) * 0.8F);
   }
 
   private KerberosTicket getTGT() {
@@ -138,8 +142,8 @@ class KerberosProtocol implements AuthProtocol {
         return null;
       }
 
-      ticket = (KerberosTicket)iter.next();
-    } while(!isTGSPrincipal(ticket.getServer()));
+      ticket = (KerberosTicket) iter.next();
+    } while (!isTGSPrincipal(ticket.getServer()));
 
     return ticket;
   }
@@ -148,7 +152,9 @@ class KerberosProtocol implements AuthProtocol {
     if (principal == null) {
       return false;
     } else {
-      return principal.getName().equals("krbtgt/" + principal.getRealm() + "@" + principal.getRealm());
+      return principal
+          .getName()
+          .equals("krbtgt/" + principal.getRealm() + "@" + principal.getRealm());
     }
   }
 
@@ -157,9 +163,11 @@ class KerberosProtocol implements AuthProtocol {
       // Authenticate the Subject (the source of the request)
       // A LoginModule uses a CallbackHandler to communicate with the user to obtain authentication
       // information
-      // The LoginContext class provides the basic methods used to authenticate subjects, and provides a
+      // The LoginContext class provides the basic methods used to authenticate subjects, and
+      // provides a
       // way to develop an application independent of the underlying authentication technology
-      LoginContext loginContext = new LoginContext(
+      LoginContext loginContext =
+          new LoginContext(
               "pegasus-client",
               null,
               new TextCallbackHandler(),

--- a/src/main/java/com/xiaomi/infra/pegasus/security/KerberosProtocol.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/security/KerberosProtocol.java
@@ -53,6 +53,7 @@ class KerberosProtocol implements AuthProtocol {
   private String keyTab;
   private String principal;
   final int CHECK_TGT_INTEVAL_SECONDS = 10;
+  final ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor();
 
   KerberosProtocol(String serviceName, String serviceFqdn, String keyTab, String principal)
       throws IllegalArgumentException {
@@ -78,7 +79,6 @@ class KerberosProtocol implements AuthProtocol {
   }
 
   private void scheduleCheckTGTAndRelogin() {
-    ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor();
     service.scheduleAtFixedRate(
         () -> checkTGTAndRelogin(),
         CHECK_TGT_INTEVAL_SECONDS,

--- a/src/main/java/com/xiaomi/infra/pegasus/security/KerberosProtocol.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/security/KerberosProtocol.java
@@ -134,10 +134,10 @@ class KerberosProtocol implements AuthProtocol {
     try {
       // Authenticate the Subject (the source of the request)
       // A LoginModule uses a CallbackHandler to communicate with the user to obtain authentication
-      // information
+      // information.
       // The LoginContext class provides the basic methods used to authenticate subjects, and
-      // provides a
-      // way to develop an application independent of the underlying authentication technology
+      // provides a way to develop an application independent of the underlying authentication
+      // technology
       LoginContext loginContext =
           new LoginContext(
               "pegasus-client",

--- a/src/main/java/com/xiaomi/infra/pegasus/security/KerberosProtocol.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/security/KerberosProtocol.java
@@ -77,34 +77,6 @@ class KerberosProtocol implements AuthProtocol {
     return entry.op instanceof negotiation_operator;
   }
 
-  private static Configuration getLoginContextConfiguration(String keyTab, String principal) {
-    return new Configuration() {
-      @Override
-      public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
-        Map<String, String> options = new HashMap<>();
-        // TGT is obtained from the ticket cache.
-        options.put("useTicketCache", "true");
-        // get the principal's key from the the keytab
-        options.put("useKeyTab", "true");
-        // renew the TGT
-        options.put("renewTGT", "true");
-        // keytab or the principal's key to be stored in the Subject's private credentials.
-        options.put("storeKey", "true");
-        // the file name of the keytab to get principal's secret key.
-        options.put("keyTab", keyTab);
-        // the name of the principal that should be used
-        options.put("principal", principal);
-
-        return new AppConfigurationEntry[] {
-          new AppConfigurationEntry(
-              "com.sun.security.auth.module.Krb5LoginModule",
-              AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
-              options)
-        };
-      }
-    };
-  }
-
   private void scheduleCheckTGTAndRelogin() {
     ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor();
     service.scheduleAtFixedRate(
@@ -124,9 +96,8 @@ class KerberosProtocol implements AuthProtocol {
     this.login();
   }
 
-  // The default refresh window is 0.8.
-  // e.g. if the lifetime of a tgt is 5min, the tgt will be refreshed after 4 min(5min * 0.8 = 4min)
-  // passed
+  // The default refresh window is 0.8. e.g. if the lifetime of a tgt is 5min, the tgt will be
+  // refreshed after 4 min(5min * 0.8 = 4min) passed
   private long getRefreshTime(KerberosTicket tgt) {
     long start = tgt.getStartTime().getTime();
     long end = tgt.getEndTime().getTime();
@@ -178,5 +149,33 @@ class KerberosProtocol implements AuthProtocol {
     } catch (LoginException le) {
       throw new IllegalArgumentException("login failed: ", le);
     }
+  }
+
+  private static Configuration getLoginContextConfiguration(String keyTab, String principal) {
+    return new Configuration() {
+      @Override
+      public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+        Map<String, String> options = new HashMap<>();
+        // TGT is obtained from the ticket cache.
+        options.put("useTicketCache", "true");
+        // get the principal's key from the the keytab
+        options.put("useKeyTab", "true");
+        // renew the TGT
+        options.put("renewTGT", "true");
+        // keytab or the principal's key to be stored in the Subject's private credentials.
+        options.put("storeKey", "true");
+        // the file name of the keytab to get principal's secret key.
+        options.put("keyTab", keyTab);
+        // the name of the principal that should be used
+        options.put("principal", principal);
+
+        return new AppConfigurationEntry[] {
+          new AppConfigurationEntry(
+              "com.sun.security.auth.module.Krb5LoginModule",
+              AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+              options)
+        };
+      }
+    };
   }
 }

--- a/src/main/java/com/xiaomi/infra/pegasus/security/KerberosProtocol.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/security/KerberosProtocol.java
@@ -130,9 +130,9 @@ class KerberosProtocol implements AuthProtocol {
 
   private KerberosTicket getTGT() {
     Set<KerberosTicket> tickets = this.subject.getPrivateCredentials(KerberosTicket.class);
-    Iterator iter = tickets.iterator();
 
     KerberosTicket ticket;
+    Iterator iter = tickets.iterator();
     do {
       if (!iter.hasNext()) {
         return null;

--- a/src/main/java/com/xiaomi/infra/pegasus/security/KerberosProtocol.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/security/KerberosProtocol.java
@@ -125,7 +125,8 @@ class KerberosProtocol implements AuthProtocol {
   }
 
   // The default refresh window is 0.8.
-  // e.g. if the lifetime of a tgt is 5min, the refresh window is 5min * 0.8 = 4min
+  // e.g. if the lifetime of a tgt is 5min, the tgt will be refreshed after 4 min(5min * 0.8 = 4min)
+  // passed
   private long getRefreshTime(KerberosTicket tgt) {
     long start = tgt.getStartTime().getTime();
     long end = tgt.getEndTime().getTime();

--- a/src/main/java/com/xiaomi/infra/pegasus/security/KerberosProtocol.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/security/KerberosProtocol.java
@@ -22,8 +22,15 @@ import com.sun.security.auth.callback.TextCallbackHandler;
 import com.xiaomi.infra.pegasus.operator.negotiation_operator;
 import com.xiaomi.infra.pegasus.rpc.async.ReplicaSession;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import javax.security.auth.Subject;
+import javax.security.auth.kerberos.KerberosPrincipal;
+import javax.security.auth.kerberos.KerberosTicket;
 import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
 import javax.security.auth.login.LoginContext;
@@ -41,32 +48,21 @@ class KerberosProtocol implements AuthProtocol {
   // request. The JAAS framework defines the term "subject" to represent the source of a request. A
   // subject may be any entity, such as a person or a service.
   private Subject subject;
-  // The LoginContext class provides the basic methods used to authenticate subjects, and provides a
-  // way to develop an application independent of the underlying authentication technology
-  private LoginContext loginContext;
   private String serviceName;
   private String serviceFqdn;
+  private String keyTab;
+  private String principal;
+  final int CHECK_TGT_INTEVAL = 30 * 1000;
 
   KerberosProtocol(String serviceName, String serviceFqdn, String keyTab, String principal)
       throws IllegalArgumentException {
     this.serviceName = serviceName;
     this.serviceFqdn = serviceFqdn;
-    try {
-      // Authenticate the Subject (the source of the request)
-      // A LoginModule uses a CallbackHandler to communicate with the user to obtain authentication
-      // information
-      this.subject = new Subject();
-      this.loginContext =
-          new LoginContext(
-              "pegasus-client",
-              subject,
-              new TextCallbackHandler(),
-              getLoginContextConfiguration(keyTab, principal));
-      this.loginContext.login();
-    } catch (LoginException le) {
-      throw new IllegalArgumentException("login failed: ", le);
-    }
+    this.keyTab = keyTab;
+    this.principal = principal;
 
+    this.login();
+    scheduleRefreshTGT();
     logger.info("login succeed, as user {}", subject.getPrincipals().toString());
   }
 
@@ -107,5 +103,71 @@ class KerberosProtocol implements AuthProtocol {
         };
       }
     };
+  }
+
+  private void scheduleRefreshTGT() {
+    ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor();
+    service.scheduleAtFixedRate(() -> checkTGTAndRelogin(), CHECK_TGT_INTEVAL, CHECK_TGT_INTEVAL, TimeUnit.SECONDS);
+  }
+
+  private void checkTGTAndRelogin() {
+    KerberosTicket tgt = getTGT();
+    if (tgt != null && System.currentTimeMillis() < getRefreshTime(tgt)) {
+      return;
+    }
+
+    // relogin if tgt is null or the tgt is almost expired
+    this.login();
+  }
+
+  // The default refresh window is 0.8.
+  // e.g. if the lifetime of a tgt is 5min, the refresh window is 5min * 0.8 = 4min
+  private long getRefreshTime(KerberosTicket tgt) {
+    long start = tgt.getStartTime().getTime();
+    long end = tgt.getEndTime().getTime();
+    return start + (long)((float)(end - start) * 0.8F);
+  }
+
+  private KerberosTicket getTGT() {
+    Set<KerberosTicket> tickets = this.subject.getPrivateCredentials(KerberosTicket.class);
+    Iterator iter = tickets.iterator();
+
+    KerberosTicket ticket;
+    do {
+      if (!iter.hasNext()) {
+        return null;
+      }
+
+      ticket = (KerberosTicket)iter.next();
+    } while(!isTGSPrincipal(ticket.getServer()));
+
+    return ticket;
+  }
+
+  private boolean isTGSPrincipal(KerberosPrincipal principal) {
+    if (principal == null) {
+      return false;
+    } else {
+      return principal.getName().equals("krbtgt/" + principal.getRealm() + "@" + principal.getRealm());
+    }
+  }
+
+  private void login() throws IllegalArgumentException {
+    try {
+      // Authenticate the Subject (the source of the request)
+      // A LoginModule uses a CallbackHandler to communicate with the user to obtain authentication
+      // information
+      // The LoginContext class provides the basic methods used to authenticate subjects, and provides a
+      // way to develop an application independent of the underlying authentication technology
+      LoginContext loginContext = new LoginContext(
+              "pegasus-client",
+              null,
+              new TextCallbackHandler(),
+              getLoginContextConfiguration(keyTab, principal));
+      loginContext.login();
+      this.subject = loginContext.getSubject();
+    } catch (LoginException le) {
+      throw new IllegalArgumentException("login failed: ", le);
+    }
   }
 }


### PR DESCRIPTION
If we use kerberos in jaas, we should refresh tgt in background to keep the authentication succeed.
For more details: https://levy5307.github.io/blog/jaas-tgt-renewal/
So in this pull request, I add a background thread to check and refresh the tgt periodically.

### Manual Test

Print the life time of tgt obtain in java client. And we can see the life time of this tgt is updated before it is expired(At line 8).

1. the remain lifetime of tgt: 69 seconds
2. the remain lifetime of tgt: 59 seconds
3. the remain lifetime of tgt: 49 seconds
4. the remain lifetime of tgt: 39 seconds
5. the remain lifetime of tgt: 29 seconds
6. the remain lifetime of tgt: 19 seconds
7. ***the remain lifetime of tgt: 9 seconds***
8. ***the remain lifetime of tgt: 69 seconds***
9. the remain lifetime of tgt: 59 seconds
10. the remain lifetime of tgt: 49 seconds
