### PR TITLE
refactor: improve some tests for cluster not in local mechine

### DIFF
--- a/src/test/java/com/xiaomi/infra/pegasus/client/TestBasic.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/client/TestBasic.java
@@ -6,6 +6,8 @@ package com.xiaomi.infra.pegasus.client;
 /** @author qinzuoyan */
 import com.xiaomi.infra.pegasus.client.PegasusTable.ScanRangeResult;
 import com.xiaomi.infra.pegasus.client.PegasusTableInterface.MultiGetSortKeysResult;
+import com.xiaomi.infra.pegasus.tools.Utils;
+
 import io.netty.util.concurrent.Future;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -2258,7 +2260,7 @@ public class TestBasic {
   @Test
   public void createClient() throws PException {
     System.out.println("test createClient with clientOptions");
-    ClientOptions clientOptions = ClientOptions.create();
+    ClientOptions clientOptions = Utils.getClientOptions();
     byte[] value = null;
 
     // test createClient(clientOptions)
@@ -2318,7 +2320,7 @@ public class TestBasic {
 
     // test getSingletonClient(ClientOptions options) --> different clientOptions,but values of
     // clientOptions is same
-    ClientOptions clientOptions1 = ClientOptions.create();
+    ClientOptions clientOptions1 = Utils.getClientOptions();
     try {
       singletonClient1 = PegasusClientFactory.getSingletonClient(clientOptions1);
       singletonClient1.set(
@@ -2339,11 +2341,9 @@ public class TestBasic {
 
     // test getSingletonClient(ClientOptions options) --> different clientOptions,and values of
     // clientOptions is different
-    ClientOptions clientOptions2 =
-        ClientOptions.builder()
-            .metaServers("127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603")
-            .asyncWorkers(5) // default value is 4,this set different value
-            .build();
+    ClientOptions clientOptions2 = Utils.getClientOptionsBuilder()
+        .asyncWorkers(5) // default value is 4,this set different value
+        .build();
     try {
       singletonClient1 = PegasusClientFactory.getSingletonClient(clientOptions2);
       singletonClient1.set(
@@ -2516,7 +2516,7 @@ public class TestBasic {
     PegasusClientInterface client1 = PegasusClientFactory.getSingletonClient();
     testWriteSizeLimit(client1);
     // Test config from ClientOptions
-    ClientOptions clientOptions = ClientOptions.create();
+    ClientOptions clientOptions = Utils.getClientOptions();
     PegasusClientInterface client2 = PegasusClientFactory.createClient(clientOptions);
     testWriteSizeLimit(client2);
   }

--- a/src/test/java/com/xiaomi/infra/pegasus/client/TestBasic.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/client/TestBasic.java
@@ -2260,7 +2260,7 @@ public class TestBasic {
   @Test
   public void createClient() throws PException {
     System.out.println("test createClient with clientOptions");
-    ClientOptions clientOptions = Utils.getClientOptions();
+    ClientOptions clientOptions = ClientOptions.create("resource:///pegasus.properties");
     byte[] value = null;
 
     // test createClient(clientOptions)
@@ -2320,7 +2320,7 @@ public class TestBasic {
 
     // test getSingletonClient(ClientOptions options) --> different clientOptions,but values of
     // clientOptions is same
-    ClientOptions clientOptions1 = Utils.getClientOptions();
+    ClientOptions clientOptions1 = ClientOptions.create("resource:///pegasus.properties");
     try {
       singletonClient1 = PegasusClientFactory.getSingletonClient(clientOptions1);
       singletonClient1.set(
@@ -2516,7 +2516,7 @@ public class TestBasic {
     PegasusClientInterface client1 = PegasusClientFactory.getSingletonClient();
     testWriteSizeLimit(client1);
     // Test config from ClientOptions
-    ClientOptions clientOptions = Utils.getClientOptions();
+    ClientOptions clientOptions = ClientOptions.create("resource:///pegasus.properties");
     PegasusClientInterface client2 = PegasusClientFactory.createClient(clientOptions);
     testWriteSizeLimit(client2);
   }

--- a/src/test/java/com/xiaomi/infra/pegasus/tools/Utils.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/tools/Utils.java
@@ -26,17 +26,6 @@ import com.xiaomi.infra.pegasus.client.PException;
 import java.util.Properties;
 
 public class Utils {
-  /**
-   * Get {@link ClientOptions} from pegasus.properties
-   *
-   * @return ClientOptions
-   */
-  public static ClientOptions getClientOptions() throws PException {
-    Properties properties = PConfigUtil.loadConfiguration("resource:///pegasus.properties");
-    String metaServers = properties.getProperty(ClientOptions.PEGASUS_META_SERVERS_KEY);
-    return ClientOptions.builder().metaServers(metaServers).build();
-  }
-
     /**
      * Get {@link ClientOptions.Builder} from pegasus.properties
      *

--- a/src/test/java/com/xiaomi/infra/pegasus/tools/Utils.java
+++ b/src/test/java/com/xiaomi/infra/pegasus/tools/Utils.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.xiaomi.infra.pegasus.tools;
+
+import com.xiaomi.infra.pegasus.client.ClientOptions;
+import com.xiaomi.infra.pegasus.client.PConfigUtil;
+import com.xiaomi.infra.pegasus.client.PException;
+
+import java.util.Properties;
+
+public class Utils {
+  /**
+   * Get {@link ClientOptions} from pegasus.properties
+   *
+   * @return ClientOptions
+   */
+  public static ClientOptions getClientOptions() throws PException {
+    Properties properties = PConfigUtil.loadConfiguration("resource:///pegasus.properties");
+    String metaServers = properties.getProperty(ClientOptions.PEGASUS_META_SERVERS_KEY);
+    return ClientOptions.builder().metaServers(metaServers).build();
+  }
+
+    /**
+     * Get {@link ClientOptions.Builder} from pegasus.properties
+     *
+     * @return ClientOptions
+     */
+    public static ClientOptions.Builder getClientOptionsBuilder() throws PException {
+        Properties properties = PConfigUtil.loadConfiguration("resource:///pegasus.properties");
+        String metaServers = properties.getProperty(ClientOptions.PEGASUS_META_SERVERS_KEY);
+        return ClientOptions.builder().metaServers(metaServers);
+    }
+}


### PR DESCRIPTION
Sometimes，the cluster to test is not in local mechine, then some test will fail.
Refact to get client options with pegasus.properties file.